### PR TITLE
feat(phase4): pipeline ordering, L1 enforcement, and audit logging

### DIFF
--- a/hooks/hooks-cursor.json
+++ b/hooks/hooks-cursor.json
@@ -1,6 +1,16 @@
 {
   "version": 1,
   "hooks": {
+    "preToolUse": [
+      {
+        "command": "./hooks/pre-tool-use"
+      }
+    ],
+    "postToolUse": [
+      {
+        "command": "./hooks/post-tool-use"
+      }
+    ],
     "sessionStart": [
       {
         "command": "./hooks/session-start"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,29 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-tool-use",
+            "async": false
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" post-tool-use",
+            "async": true
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup|clear|compact",

--- a/hooks/lib/artifact.sh
+++ b/hooks/lib/artifact.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source pipeline.sh from the same directory
+_artifact_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+source "$_artifact_script_dir/pipeline.sh"
+
+# ARTIFACT_FILES — array of 6 known artifact paths
+declare -a ARTIFACT_FILES=(
+  "goals.md"
+  "questions.md"
+  "research/summary.md"
+  "design.md"
+  "structure.md"
+  "plan.md"
+)
+
+# artifact_is_known <file_path> <artifact_dir>
+# Checks if file_path matches a known artifact by comparing path suffix.
+# Returns 0 with step name on stdout if matched (goals, questions, research, design, structure, plan).
+# Returns 1 if not a known artifact.
+artifact_is_known() {
+  local file_path="$1"
+  local artifact_dir="$2"
+
+  # Resolve artifact_dir to absolute path
+  artifact_dir=$(cd "$artifact_dir" 2>/dev/null && pwd) || return 1
+
+  # Resolve file_path to absolute path if possible
+  local abs_file_path
+  if [[ "$file_path" =~ ^/ ]]; then
+    abs_file_path="$file_path"
+  else
+    abs_file_path="$(cd "$(dirname "$file_path")" 2>/dev/null && pwd)/$(basename "$file_path")" || return 1
+  fi
+
+  # Check if file_path is under artifact_dir (require exact prefix + /)
+  # Without the trailing slash check, /path/to/artifacts-evil/goals.md
+  # would falsely match /path/to/artifacts as a prefix.
+  if [[ "$abs_file_path" != "$artifact_dir/"* ]]; then
+    return 1
+  fi
+
+  # Strip artifact_dir prefix to get relative path
+  local rel_path="${abs_file_path#"$artifact_dir/"}"
+
+  # Map known artifacts to step names
+  case "$rel_path" in
+    "goals.md")
+      echo "goals"
+      return 0
+      ;;
+    "questions.md")
+      echo "questions"
+      return 0
+      ;;
+    "research/summary.md")
+      echo "research"
+      return 0
+      ;;
+    "design.md")
+      echo "design"
+      return 0
+      ;;
+    "structure.md")
+      echo "structure"
+      return 0
+      ;;
+    "plan.md")
+      echo "plan"
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# artifact_sync_state <file_path> <artifact_dir>
+# Called after a known artifact is written:
+# - Reads frontmatter status via frontmatter_get_status
+# - If status: approved → update state.json artifacts map to set that step = "approved"
+# - If status: draft → call pipeline_cascade_reset to reset that step and all downstream
+# - For design.md specifically: also read wireframe_requested field and sync to state.json
+artifact_sync_state() {
+  local file_path="$1"
+  local artifact_dir="$2"
+
+  # Get the step name for this artifact
+  local step
+  step=$(artifact_is_known "$file_path" "$artifact_dir") || return 1
+
+  # Read frontmatter status
+  local fm_status
+  fm_status=$(frontmatter_get_status "$file_path") || return 1
+
+  # Read current state
+  local state
+  state=$(state_read) || return 1
+
+  # Check if status actually changed before writing — avoids unnecessary
+  # state writes and cascade resets on every artifact edit
+  local current_status
+  current_status=$(echo "$state" | jq -r ".artifacts.$step // \"draft\"")
+  local state_changed=false
+
+  if [[ "$fm_status" == "$current_status" ]]; then
+    # Status unchanged — no state update needed
+    :
+  elif [[ "$fm_status" == "approved" ]]; then
+    # Update that step to approved
+    state=$(echo "$state" | jq -c ".artifacts.$step = \"approved\"")
+    state_changed=true
+  elif [[ "$fm_status" == "draft" ]]; then
+    # Cascade reset from this step onwards
+    pipeline_cascade_reset "$step" "$artifact_dir"
+    state=$(state_read)
+    state_changed=true
+  fi
+
+  # For design.md specifically: sync wireframe_requested field
+  if [[ "$step" == "design" ]]; then
+    # Read the design.md file and extract wireframe_requested from frontmatter
+    # Look for "wireframe_requested: true" or "wireframe_requested: false"
+    local wireframe_str_value="false"
+
+    # Read first 10 lines to find wireframe_requested
+    local line_num=0
+    local in_frontmatter=0
+    while IFS= read -r line && [[ $line_num -lt 10 ]]; do
+      line_num=$((line_num + 1))
+
+      # Line 1: must be opening ---
+      if [[ $line_num -eq 1 ]]; then
+        if [[ "$line" == "---" ]]; then
+          in_frontmatter=1
+        else
+          break
+        fi
+        continue
+      fi
+
+      # Lines 2+: look for closing --- or wireframe_requested field
+      if [[ $in_frontmatter -eq 1 ]]; then
+        if [[ "$line" == "---" ]]; then
+          break
+        fi
+
+        # Check for wireframe_requested field
+        if [[ "$line" =~ ^wireframe_requested: ]]; then
+          local value="${line#wireframe_requested:}"
+          value="${value#"${value%%[![:space:]]*}"}"  # trim leading whitespace
+          value="${value%"${value##*[![:space:]]}"}"  # trim trailing whitespace
+          wireframe_str_value="$value"
+        fi
+      fi
+    done < "$file_path"
+
+    # Convert string to JSON boolean value
+    local wireframe_json_value="false"
+    if [[ "$wireframe_str_value" == "true" ]]; then
+      wireframe_json_value="true"
+    fi
+
+    # Check if wireframe value actually changed
+    local current_wireframe
+    current_wireframe=$(echo "$state" | jq -r '.wireframe_requested // false')
+    if [[ "$current_wireframe" != "$wireframe_json_value" ]]; then
+      state=$(echo "$state" | jq -c ".wireframe_requested = $wireframe_json_value")
+      state_changed=true
+    fi
+  fi
+
+  # Only write state if something actually changed
+  if [[ "$state_changed" == true ]]; then
+    state_write_atomic "$state"
+  fi
+}

--- a/hooks/lib/audit.sh
+++ b/hooks/lib/audit.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source the task library for task ID resolution
+source "$(dirname "${BASH_SOURCE[0]}")/task.sh"
+
+# audit_log_operation <task_id> <timestamp> <tool> <target> <targets_json> <command> <in_scope> <enforcement> <user_approved> <destructive_flag>
+#
+# Appends a single JSON line to .qrspi/audit-task-NN.jsonl (NN = zero-padded task_id).
+#
+# Arguments:
+#   task_id          - Task ID (e.g., 3, 15)
+#   timestamp        - ISO 8601 timestamp
+#   tool             - "Write", "Edit", or "Bash"
+#   target           - Primary file path (string)
+#   targets_json     - JSON array of all target paths
+#   command          - Full command string for Bash, "null" for Write/Edit
+#   in_scope         - "true" or "false" string
+#   enforcement      - "strict" or "monitored"
+#   user_approved    - "true" or "false" string
+#   destructive_flag - Pattern name or "null" string
+#
+audit_log_operation() {
+  local task_id="$1"
+  local timestamp="$2"
+  local tool="$3"
+  local target="$4"
+  local targets_json="$5"
+  local command="$6"
+  local in_scope="$7"
+  local enforcement="$8"
+  local user_approved="$9"
+  local destructive_flag="${10}"
+
+  # Create .qrspi directory if it doesn't exist
+  mkdir -p .qrspi
+
+  # Convert task_id to zero-padded format (e.g., 3 -> 03, 15 -> 15)
+  local padded_task_id=$(printf "%02d" "$task_id")
+  local audit_file=".qrspi/audit-task-${padded_task_id}.jsonl"
+
+  # Sanitize boolean inputs: ensure they are exactly "true" or "false"
+  # so jq's --argjson can parse them as JSON booleans (not strings).
+  # Without this, an unexpected value like "yes" or "" would crash jq.
+  local in_scope_bool=$([ "$in_scope" = "true" ] && echo "true" || echo "false")
+  local user_approved_bool=$([ "$user_approved" = "true" ] && echo "true" || echo "false")
+
+  # Build the JSON record using jq with proper escaping
+  local json_record
+  if [ "$command" = "null" ] && [ "$destructive_flag" = "null" ]; then
+    json_record=$(jq -cn \
+      --arg timestamp "$timestamp" \
+      --arg tool "$tool" \
+      --arg target "$target" \
+      --argjson targets "$targets_json" \
+      --arg enforcement "$enforcement" \
+      --argjson in_scope "$in_scope_bool" \
+      --argjson user_approved "$user_approved_bool" \
+      '{timestamp: $timestamp, tool: $tool, target: $target, targets: $targets, command: null, in_scope: $in_scope, enforcement: $enforcement, user_approved: $user_approved, destructive_flag: null}')
+  elif [ "$command" = "null" ]; then
+    json_record=$(jq -cn \
+      --arg timestamp "$timestamp" \
+      --arg tool "$tool" \
+      --arg target "$target" \
+      --argjson targets "$targets_json" \
+      --arg enforcement "$enforcement" \
+      --argjson in_scope "$in_scope_bool" \
+      --argjson user_approved "$user_approved_bool" \
+      --arg destructive_flag "$destructive_flag" \
+      '{timestamp: $timestamp, tool: $tool, target: $target, targets: $targets, command: null, in_scope: $in_scope, enforcement: $enforcement, user_approved: $user_approved, destructive_flag: $destructive_flag}')
+  elif [ "$destructive_flag" = "null" ]; then
+    json_record=$(jq -cn \
+      --arg timestamp "$timestamp" \
+      --arg tool "$tool" \
+      --arg target "$target" \
+      --argjson targets "$targets_json" \
+      --arg command "$command" \
+      --arg enforcement "$enforcement" \
+      --argjson in_scope "$in_scope_bool" \
+      --argjson user_approved "$user_approved_bool" \
+      '{timestamp: $timestamp, tool: $tool, target: $target, targets: $targets, command: $command, in_scope: $in_scope, enforcement: $enforcement, user_approved: $user_approved, destructive_flag: null}')
+  else
+    json_record=$(jq -cn \
+      --arg timestamp "$timestamp" \
+      --arg tool "$tool" \
+      --arg target "$target" \
+      --argjson targets "$targets_json" \
+      --arg command "$command" \
+      --arg enforcement "$enforcement" \
+      --argjson in_scope "$in_scope_bool" \
+      --argjson user_approved "$user_approved_bool" \
+      --arg destructive_flag "$destructive_flag" \
+      '{timestamp: $timestamp, tool: $tool, target: $target, targets: $targets, command: $command, in_scope: $in_scope, enforcement: $enforcement, user_approved: $user_approved, destructive_flag: $destructive_flag}')
+  fi
+
+  # Append to file
+  echo "$json_record" >> "$audit_file"
+}

--- a/hooks/lib/bash-detect.sh
+++ b/hooks/lib/bash-detect.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bash_detect_file_writes() {
+    local cmd="$1"
+    local paths=()
+
+    # Split on compound operators (&&, ||, ;) to handle multiple commands
+    local parts=()
+    local current=""
+    local i=0
+
+    while [[ $i -lt ${#cmd} ]]; do
+        local char="${cmd:$i:1}"
+        local next_two="${cmd:$i:2}"
+
+        # Check for compound operators
+        if [[ "$next_two" == "&&" ]] || [[ "$next_two" == "||" ]]; then
+            if [[ -n "$current" ]]; then
+                parts+=("$current")
+            fi
+            current=""
+            i=$((i+2))
+        elif [[ "$char" == ";" ]]; then
+            if [[ -n "$current" ]]; then
+                parts+=("$current")
+            fi
+            current=""
+            i=$((i+1))
+        else
+            current+="$char"
+            i=$((i+1))
+        fi
+    done
+    [[ -n "$current" ]] && parts+=("$current")
+
+    # Process each part of the compound command
+    for part in "${parts[@]}"; do
+        part="${part## }"  # Trim leading whitespace
+        part="${part%% }"  # Trim trailing whitespace
+
+        # Pattern 1: Output redirect (> or >>)
+        if [[ "$part" =~ \>\>?[[:space:]]+\"?([^\"]+)\"? ]]; then
+            local path="${BASH_REMATCH[1]}"
+            # Remove quotes if present
+            path="${path%\"}"
+            path="${path#\"}"
+            path="${path%\'}"
+            path="${path#\'}"
+            [[ -n "$path" ]] && paths+=("$path")
+        fi
+
+        # Pattern 2: sed -i or sed -i.bak
+        if [[ "$part" =~ sed[[:space:]]+-i ]]; then
+            # Extract the filename (last argument after the sed pattern)
+            local sed_match=""
+            if [[ "$part" =~ sed[[:space:]]+-i\.[a-zA-Z0-9]+[[:space:]]+\'[^\']*\'[[:space:]]+([^ ]+) ]]; then
+                sed_match="${BASH_REMATCH[1]}"
+            elif [[ "$part" =~ sed[[:space:]]+-i\.[a-zA-Z0-9]+[[:space:]]+\"[^\"]*\"[[:space:]]+([^ ]+) ]]; then
+                sed_match="${BASH_REMATCH[1]}"
+            elif [[ "$part" =~ sed[[:space:]]+-i\.[a-zA-Z0-9]+[[:space:]]+[^[:space:]]+[[:space:]]+([^ ]+)$ ]]; then
+                sed_match="${BASH_REMATCH[1]}"
+            elif [[ "$part" =~ sed[[:space:]]+-i[[:space:]]+\'[^\']*\'[[:space:]]+([^ ]+) ]]; then
+                sed_match="${BASH_REMATCH[1]}"
+            elif [[ "$part" =~ sed[[:space:]]+-i[[:space:]]+\"[^\"]*\"[[:space:]]+([^ ]+) ]]; then
+                sed_match="${BASH_REMATCH[1]}"
+            elif [[ "$part" =~ sed[[:space:]]+-i[[:space:]]+[^[:space:]]+[[:space:]]+([^ ]+)$ ]]; then
+                sed_match="${BASH_REMATCH[1]}"
+            fi
+            [[ -n "$sed_match" ]] && paths+=("$sed_match")
+        fi
+
+        # Pattern 3: cp source dest
+        if [[ "$part" =~ ^cp[[:space:]]+ ]]; then
+            local args_str="${part#cp}"
+            args_str="${args_str## }"
+            local last_arg=$(echo "$args_str" | awk '{print $NF}')
+            if [[ ! "$last_arg" =~ ^- ]]; then
+                last_arg="${last_arg%\"}"
+                last_arg="${last_arg#\"}"
+                last_arg="${last_arg%\'}"
+                last_arg="${last_arg#\'}"
+                [[ -n "$last_arg" ]] && paths+=("$last_arg")
+            fi
+        fi
+
+        # Pattern 4: mv old new
+        if [[ "$part" =~ ^mv[[:space:]]+ ]]; then
+            local args_str="${part#mv}"
+            args_str="${args_str## }"
+            local last_arg=$(echo "$args_str" | awk '{print $NF}')
+            if [[ ! "$last_arg" =~ ^- ]]; then
+                last_arg="${last_arg%\"}"
+                last_arg="${last_arg#\"}"
+                last_arg="${last_arg%\'}"
+                last_arg="${last_arg#\'}"
+                [[ -n "$last_arg" ]] && paths+=("$last_arg")
+            fi
+        fi
+
+        # Pattern 5: tee or tee -a
+        if [[ "$part" =~ tee[[:space:]]+ ]]; then
+            local tee_match=""
+            if [[ "$part" =~ tee[[:space:]]+-a[[:space:]]+\"?([^\"]+)\"? ]]; then
+                tee_match="${BASH_REMATCH[1]}"
+            elif [[ "$part" =~ tee[[:space:]]+\"?([^\"]+)\"? ]]; then
+                tee_match="${BASH_REMATCH[1]}"
+            fi
+            if [[ -n "$tee_match" ]]; then
+                tee_match="${tee_match%\"}"
+                tee_match="${tee_match#\"}"
+                tee_match="${tee_match%\'}"
+                tee_match="${tee_match#\'}"
+                [[ -n "$tee_match" ]] && paths+=("$tee_match")
+            fi
+        fi
+    done
+
+    # Output results (one per line)
+    for path in "${paths[@]}"; do
+        echo "$path"
+    done
+
+    return 0
+}

--- a/hooks/lib/enforcement.sh
+++ b/hooks/lib/enforcement.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source the task library (which transitively sources frontmatter.sh)
+source "$(dirname "${BASH_SOURCE[0]}")/task.sh"
+
+# enforcement_get_mode <task_id> <artifact_dir>
+# Determines the enforcement mode for a task.
+# Checks runtime overrides first for mode override; falls back to task spec.
+# If no Phase 4 fields present, returns "strict" (fail-closed).
+# Outputs mode string on stdout.
+enforcement_get_mode() {
+  local task_id="$1"
+  local artifact_dir="$2"
+
+  # Check runtime overrides first (user mid-task decisions take precedence)
+  local overrides_json
+  if overrides_json=$(task_read_runtime_overrides "$task_id" 2>/dev/null); then
+    local overrides_mode
+    overrides_mode=$(echo "$overrides_json" | jq -r '.enforcement // empty' 2>/dev/null || true)
+    if [[ -n "$overrides_mode" && "$overrides_mode" != "null" ]]; then
+      echo "$overrides_mode"
+      return 0
+    fi
+  fi
+
+  # Fall back to task spec
+  local spec_path
+  spec_path=$(task_get_spec_path "$task_id" "$artifact_dir")
+
+  if [[ ! -f "$spec_path" ]]; then
+    echo "strict"
+    return 0
+  fi
+
+  local frontmatter_json
+  frontmatter_json=$(task_read_frontmatter "$spec_path")
+  local mode
+  mode=$(echo "$frontmatter_json" | jq -r '.enforcement // "strict"')
+
+  echo "$mode"
+}
+
+# enforcement_check_allowlist <file_path> <task_id> <artifact_dir>
+# Checks if a file is allowed for the given task.
+# In monitored mode: always returns 0.
+# In strict mode: returns 0 if file is in allowed_files or overrides user_approved_files,
+#                 returns 2 if not (also writes three-option message to stderr).
+# Path matching: strips working directory prefix from file_path to get relative path.
+enforcement_check_allowlist() {
+  local file_path="$1"
+  local task_id="$2"
+  local artifact_dir="$3"
+
+  # Get enforcement mode
+  local mode
+  mode=$(enforcement_get_mode "$task_id" "$artifact_dir")
+
+  # Validate mode — unrecognized values fail closed
+  if [[ "$mode" != "strict" && "$mode" != "monitored" ]]; then
+    echo "enforcement_check_allowlist: unrecognized mode '$mode' for task $task_id — defaulting to strict" >&2
+    mode="strict"
+  fi
+
+  # Monitored mode: always allow
+  if [[ "$mode" != "strict" ]]; then
+    return 0
+  fi
+
+  # Convert absolute path to relative so it matches allowlist entries.
+  # Claude Code sends absolute paths (e.g., /Users/.../project/src/main.sh)
+  # but task specs declare allowed files as relative (e.g., src/main.sh).
+  # If the file is outside the working directory (e.g., /tmp/foo), the
+  # absolute path is kept — it won't match any allowlist entry and will
+  # be blocked.
+  local rel_path="$file_path"
+  local cwd
+  cwd="$(pwd)"
+  if [[ "$file_path" == /* ]]; then
+    rel_path="${file_path#"${cwd}/"}"
+    if [[ "$rel_path" == /* ]]; then
+      rel_path="$file_path"
+    fi
+  fi
+
+  # Read allowed_files from task spec
+  local spec_path
+  spec_path=$(task_get_spec_path "$task_id" "$artifact_dir")
+  local frontmatter_json
+  frontmatter_json=$(task_read_frontmatter "$spec_path")
+  local spec_allowed
+  spec_allowed=$(echo "$frontmatter_json" | jq -r '.allowed_files[].path' 2>/dev/null || true)
+
+  # Check spec allowed_files
+  while IFS= read -r allowed_path; do
+    if [[ -n "$allowed_path" && "$allowed_path" == "$rel_path" ]]; then
+      return 0
+    fi
+  done <<< "$spec_allowed"
+
+  # Check overrides user_approved_files
+  local overrides_json
+  if overrides_json=$(task_read_runtime_overrides "$task_id" 2>/dev/null); then
+    local overrides_approved
+    overrides_approved=$(echo "$overrides_json" | jq -r '.user_approved_files[]?' 2>/dev/null || true)
+    while IFS= read -r approved_path; do
+      if [[ -n "$approved_path" && "$approved_path" == "$rel_path" ]]; then
+        return 0
+      fi
+    done <<< "$overrides_approved"
+  fi
+
+  # File is not in either list — blocked
+  local padded_id
+  padded_id=$(printf "%02d" "$task_id")
+  printf "BLOCKED: File '%s' is not in the allowlist for task %s.\nOptions:\n  1. approve this file (add to runtime allowlist)\n  2. switch to monitored mode for this task\n  3. reject and stop\n" \
+    "$rel_path" "$padded_id" >&2
+
+  return 2
+}

--- a/hooks/lib/frontmatter.sh
+++ b/hooks/lib/frontmatter.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# frontmatter_get_status <file>
+# Extracts the status field from YAML frontmatter (first 5 lines only).
+# Frontmatter must be properly delimited with --- on both sides.
+# Returns 0 with status value on stdout if found, 1 otherwise.
+frontmatter_get_status() {
+  local file="$1"
+
+  # Check if file exists
+  [[ -f "$file" ]] || return 1
+
+  # Read first 5 lines
+  local line_num=0
+  local in_frontmatter=0
+  local found_closing=0
+  local status_value=""
+
+  while IFS= read -r line && [[ $line_num -lt 5 ]]; do
+    line_num=$((line_num + 1))
+
+    # Line 1: must be opening ---
+    if [[ $line_num -eq 1 ]]; then
+      if [[ "$line" == "---" ]]; then
+        in_frontmatter=1
+      else
+        return 1
+      fi
+      continue
+    fi
+
+    # Lines 2-5: look for closing --- or status field
+    if [[ $in_frontmatter -eq 1 ]]; then
+      if [[ "$line" == "---" ]]; then
+        found_closing=1
+        break
+      fi
+
+      # Check for status field
+      if [[ "$line" =~ ^status: ]]; then
+        # Extract and trim the value
+        local value="${line#status:}"
+        value="${value#"${value%%[![:space:]]*}"}"  # trim leading whitespace
+        value="${value%"${value##*[![:space:]]}"}"  # trim trailing whitespace
+        status_value="$value"
+      fi
+    fi
+  done < "$file"
+
+  # Must have found closing --- and status value
+  if [[ "$found_closing" -eq 1 && -n "$status_value" ]]; then
+    echo "$status_value"
+    return 0
+  fi
+
+  return 1
+}

--- a/hooks/lib/pipeline.sh
+++ b/hooks/lib/pipeline.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source state.sh (which transitively sources frontmatter.sh)
+_pipeline_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+source "$_pipeline_script_dir/state.sh"
+
+# PIPELINE_ORDER — readonly array of 8 steps in order
+# Use +a to disable readonly temporarily for proper array declaration, then re-enable
+declare -a PIPELINE_ORDER=(goals questions research design structure plan implement test)
+declare -r PIPELINE_ORDER
+
+# _pipeline_get_step_index <step>
+# Returns the index of the step in PIPELINE_ORDER (0-7), or -1 if not found
+_pipeline_get_step_index() {
+  local step="$1"
+  case "$step" in
+    goals) echo 0 ;;
+    questions) echo 1 ;;
+    research) echo 2 ;;
+    design) echo 3 ;;
+    structure) echo 4 ;;
+    plan) echo 5 ;;
+    implement) echo 6 ;;
+    test) echo 7 ;;
+    *) echo -1 ;;
+  esac
+}
+
+# _pipeline_get_artifact_file <step> <artifact_dir>
+# Returns the path to the artifact file for the given step, or empty string if no file
+_pipeline_get_artifact_file() {
+  local step="$1"
+  local artifact_dir="$2"
+  case "$step" in
+    goals) echo "$artifact_dir/goals.md" ;;
+    questions) echo "$artifact_dir/questions.md" ;;
+    research) echo "$artifact_dir/research/summary.md" ;;
+    design) echo "$artifact_dir/design.md" ;;
+    structure) echo "$artifact_dir/structure.md" ;;
+    plan) echo "$artifact_dir/plan.md" ;;
+    implement) echo "" ;;
+    test) echo "" ;;
+    *) echo "" ;;
+  esac
+}
+
+# pipeline_check_prerequisites <step> <artifact_dir>
+# Verifies all steps before the given step are approved.
+# Does a dual check: reads state.json AND checks artifact frontmatter on disk.
+# If state says approved but frontmatter says draft, trust frontmatter.
+# Returns 0 if all prerequisites met.
+# Returns 1 with the first missing prerequisite name on stdout if not met.
+# Returns 1 for invalid step names.
+# "goals" has no prerequisites → always returns 0.
+pipeline_check_prerequisites() {
+  local step="$1"
+  local artifact_dir="$2"
+
+  # Validate step
+  local step_idx
+  step_idx=$(_pipeline_get_step_index "$step")
+  if [[ $step_idx -eq -1 ]]; then
+    return 1
+  fi
+
+  # "goals" has no prerequisites
+  if [[ "$step" == "goals" ]]; then
+    return 0
+  fi
+
+  # Read state.json
+  local state
+  if ! state=$(state_read 2>/dev/null); then
+    return 1
+  fi
+
+  # Check each prerequisite step (index 0 to step_idx-1)
+  local i
+  for (( i = 0; i < step_idx; i++ )); do
+    # Get step name at index i
+    local current_step
+    case "$i" in
+      0) current_step="goals" ;;
+      1) current_step="questions" ;;
+      2) current_step="research" ;;
+      3) current_step="design" ;;
+      4) current_step="structure" ;;
+      5) current_step="plan" ;;
+      6) current_step="implement" ;;
+      7) current_step="test" ;;
+      *) current_step="" ;;
+    esac
+
+    # Get status from state
+    local state_status
+    state_status=$(echo "$state" | jq -r ".artifacts.$current_step // \"draft\"")
+
+    # Dual check: verify against frontmatter on disk
+    local frontmatter_status="draft"
+
+    # Get artifact file path
+    local artifact_file
+    artifact_file=$(_pipeline_get_artifact_file "$current_step" "$artifact_dir")
+
+    # Read frontmatter status if file exists
+    if [[ -n "$artifact_file" && -f "$artifact_file" ]]; then
+      if fm_status=$(frontmatter_get_status "$artifact_file" 2>/dev/null); then
+        frontmatter_status="$fm_status"
+      fi
+    fi
+
+    # Trust frontmatter (source of truth)
+    if [[ "$frontmatter_status" != "approved" ]]; then
+      echo "$current_step"
+      return 1
+    fi
+  done
+
+  # All prerequisites met
+  return 0
+}
+
+# pipeline_cascade_reset <step> <artifact_dir>
+# Resets the given step and all downstream steps to "draft" in state.json.
+# Does NOT modify artifact files on disk.
+# Uses state_write_atomic().
+# If step is "goals", resets all 8.
+# If step is "test", resets only test.
+pipeline_cascade_reset() {
+  local step="$1"
+  local artifact_dir="$2"
+
+  # Read current state
+  local state
+  if ! state=$(state_read 2>/dev/null); then
+    # No state file yet, create one
+    state_init_or_reconcile "$artifact_dir"
+    state=$(state_read)
+  fi
+
+  # Find the index of the step
+  local start_idx
+  start_idx=$(_pipeline_get_step_index "$step")
+  if [[ $start_idx -eq -1 ]]; then
+    return 1
+  fi
+
+  # Reset from start_idx to end to "draft"
+  local i
+  for (( i = start_idx; i < 8; i++ )); do
+    local reset_step
+    case "$i" in
+      0) reset_step="goals" ;;
+      1) reset_step="questions" ;;
+      2) reset_step="research" ;;
+      3) reset_step="design" ;;
+      4) reset_step="structure" ;;
+      5) reset_step="plan" ;;
+      6) reset_step="implement" ;;
+      7) reset_step="test" ;;
+      *) reset_step="" ;;
+    esac
+    state=$(echo "$state" | jq ".artifacts.$reset_step = \"draft\"")
+  done
+
+  # Write atomically
+  state_write_atomic "$state"
+}

--- a/hooks/lib/protected.sh
+++ b/hooks/lib/protected.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+protected_is_blocked() {
+  local target_path="$1"
+  local is_worktree="$2"
+
+  # Only block if IN a worktree (is_worktree=0 means worktree detected).
+  # Worktree subagents must not modify pipeline infrastructure files
+  # (task specs, state, audit logs). Main session can modify them freely.
+  if [[ $is_worktree -ne 0 ]]; then
+    return 1
+  fi
+
+  # Check protected patterns
+  case "$target_path" in
+    tasks/task-*.md)
+      return 0
+      ;;
+    .qrspi/state.json)
+      return 0
+      ;;
+    .qrspi/task-*-runtime.json)
+      return 0
+      ;;
+    config.md)
+      return 0
+      ;;
+    .qrspi/audit-task-*.jsonl)
+      return 0
+      ;;
+    reviews/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}

--- a/hooks/lib/state.sh
+++ b/hooks/lib/state.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source frontmatter.sh from the same directory
+# Use a more robust method that works in all contexts
+_state_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+source "$_state_script_dir/frontmatter.sh"
+
+# state_init_or_reconcile <artifact_dir>
+# Scans artifact files in the given directory, reads their frontmatter status,
+# and creates/updates .qrspi/state.json in the current working directory.
+state_init_or_reconcile() {
+  local artifact_dir="$1"
+
+  # Check if artifact_dir exists
+  [[ -d "$artifact_dir" ]] || return 1
+
+  # Determine statuses for all 8 artifacts
+  local goals_status="draft"
+  local questions_status="draft"
+  local research_status="draft"
+  local design_status="draft"
+  local structure_status="draft"
+  local plan_status="draft"
+  local implement_status="draft"
+  local test_status="draft"
+
+  # Check goals.md
+  if [[ -f "$artifact_dir/goals.md" ]]; then
+    goals_status=$(frontmatter_get_status "$artifact_dir/goals.md" || echo "draft")
+  fi
+
+  # Check questions.md
+  if [[ -f "$artifact_dir/questions.md" ]]; then
+    questions_status=$(frontmatter_get_status "$artifact_dir/questions.md" || echo "draft")
+  fi
+
+  # Check research/summary.md
+  if [[ -f "$artifact_dir/research/summary.md" ]]; then
+    research_status=$(frontmatter_get_status "$artifact_dir/research/summary.md" || echo "draft")
+  fi
+
+  # Check design.md
+  if [[ -f "$artifact_dir/design.md" ]]; then
+    design_status=$(frontmatter_get_status "$artifact_dir/design.md" || echo "draft")
+  fi
+
+  # Check structure.md
+  if [[ -f "$artifact_dir/structure.md" ]]; then
+    structure_status=$(frontmatter_get_status "$artifact_dir/structure.md" || echo "draft")
+  fi
+
+  # Check plan.md
+  if [[ -f "$artifact_dir/plan.md" ]]; then
+    plan_status=$(frontmatter_get_status "$artifact_dir/plan.md" || echo "draft")
+  fi
+
+  # implement and test are never read from files, always draft unless inferred
+  # (but for now we keep them as draft)
+
+  # Determine current_step: first artifact that is NOT "approved"
+  local current_step=""
+  if [[ "$goals_status" != "approved" ]]; then
+    current_step="goals"
+  elif [[ "$questions_status" != "approved" ]]; then
+    current_step="questions"
+  elif [[ "$research_status" != "approved" ]]; then
+    current_step="research"
+  elif [[ "$design_status" != "approved" ]]; then
+    current_step="design"
+  elif [[ "$structure_status" != "approved" ]]; then
+    current_step="structure"
+  elif [[ "$plan_status" != "approved" ]]; then
+    current_step="plan"
+  elif [[ "$implement_status" != "approved" ]]; then
+    current_step="implement"
+  elif [[ "$test_status" != "approved" ]]; then
+    current_step="test"
+  else
+    # All approved
+    current_step="test"
+  fi
+
+  # Create absolute path for artifact_dir
+  local abs_artifact_dir
+  abs_artifact_dir="$(cd "$artifact_dir" && pwd)"
+
+  # Create the state JSON (compact format)
+  local json
+  json=$(jq -cn \
+    --arg current_step "$current_step" \
+    --arg artifact_dir "$abs_artifact_dir" \
+    '{
+      version: 1,
+      current_step: $current_step,
+      phase_start_commit: null,
+      artifact_dir: $artifact_dir,
+      wireframe_requested: false,
+      artifacts: {
+        goals: $goals,
+        questions: $questions,
+        research: $research,
+        design: $design,
+        structure: $structure,
+        plan: $plan,
+        implement: $implement,
+        test: $test
+      },
+      active_task: null
+    }' \
+    --arg goals "$goals_status" \
+    --arg questions "$questions_status" \
+    --arg research "$research_status" \
+    --arg design "$design_status" \
+    --arg structure "$structure_status" \
+    --arg plan "$plan_status" \
+    --arg implement "$implement_status" \
+    --arg test "$test_status")
+
+  # Write the state file atomically
+  state_write_atomic "$json"
+}
+
+# state_read
+# Outputs .qrspi/state.json on stdout, returns 0.
+# Returns 1 if file doesn't exist.
+state_read() {
+  local state_file=".qrspi/state.json"
+
+  if [[ -f "$state_file" ]]; then
+    cat "$state_file"
+    return 0
+  else
+    return 1
+  fi
+}
+
+# state_write_atomic <json_string>
+# Writes JSON to .qrspi/state.json via temp file + mv for atomicity.
+# Creates .qrspi/ directory if needed.
+state_write_atomic() {
+  local json="$1"
+
+  # Create .qrspi directory if needed
+  mkdir -p ".qrspi"
+
+  # Create temp file in the same directory to ensure atomic rename
+  local temp_file
+  temp_file=$(mktemp ".qrspi/.state.json.XXXXXX")
+
+  # Write JSON to temp file
+  echo "$json" > "$temp_file"
+
+  # Atomically move temp file to final location
+  mv "$temp_file" ".qrspi/state.json"
+
+  return 0
+}

--- a/hooks/lib/task.sh
+++ b/hooks/lib/task.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source the frontmatter library
+source "$(dirname "${BASH_SOURCE[0]}")/frontmatter.sh"
+
+# task_read_frontmatter <task_file>
+# Parses YAML frontmatter from a task spec file.
+# Returns JSON with enforcement, allowed_files, and constraints.
+task_read_frontmatter() {
+  local task_file="$1"
+
+  if [[ ! -f "$task_file" ]]; then
+    return 1
+  fi
+
+  local enforcement="strict"
+  local allowed_files_json="[]"
+  local constraints_json="[]"
+
+  # Extract frontmatter block (between --- markers)
+  local in_frontmatter=0
+  local frontmatter=""
+  local line_num=0
+
+  while IFS= read -r line; do
+    line_num=$((line_num + 1))
+
+    # First --- marks start
+    if [[ $line_num -eq 1 && "$line" == "---" ]]; then
+      in_frontmatter=1
+      continue
+    fi
+
+    # Second --- marks end
+    if [[ $in_frontmatter -eq 1 && "$line" == "---" ]]; then
+      break
+    fi
+
+    # Collect frontmatter lines
+    if [[ $in_frontmatter -eq 1 ]]; then
+      frontmatter+="$line"$'\n'
+    fi
+  done < "$task_file"
+
+  # Parse enforcement
+  if [[ "$frontmatter" =~ (^|$'\n')enforcement:\ ([a-z]+) ]]; then
+    enforcement="${BASH_REMATCH[2]}"
+  fi
+
+  # Parse allowed_files array
+  local in_allowed_files=0
+  local files_array=()
+
+  while IFS= read -r line; do
+    # Check if we're at the allowed_files section
+    if [[ "$line" =~ ^allowed_files: ]]; then
+      in_allowed_files=1
+      continue
+    fi
+
+    # Exit allowed_files section when we hit a non-indented line or another field
+    if [[ $in_allowed_files -eq 1 ]] && [[ "$line" =~ ^[a-z] ]]; then
+      in_allowed_files=0
+    fi
+
+    # Parse list items
+    if [[ $in_allowed_files -eq 1 && "$line" =~ ^[[:space:]]*-[[:space:]]action: ]]; then
+      local action_line="$line"
+      local action=""
+      local path=""
+
+      # Extract action from current line
+      if [[ "$action_line" =~ action:[[:space:]]+([a-z]+) ]]; then
+        action="${BASH_REMATCH[1]}"
+      fi
+
+      # Read the next line for path (should be indented with path:)
+      IFS= read -r path_line || break
+      if [[ "$path_line" =~ path:[[:space:]]+(.*) ]]; then
+        path="${BASH_REMATCH[1]}"
+      fi
+
+      # Add to files array
+      if [[ -n "$action" && -n "$path" ]]; then
+        files_array+=("{\"action\": \"$action\", \"path\": \"$path\"}")
+      fi
+    fi
+  done <<< "$frontmatter"
+
+  # Build allowed_files JSON
+  if [[ ${#files_array[@]} -gt 0 ]]; then
+    allowed_files_json="["
+    for i in "${!files_array[@]}"; do
+      allowed_files_json+="${files_array[$i]}"
+      if [[ $i -lt $((${#files_array[@]} - 1)) ]]; then
+        allowed_files_json+=","
+      fi
+    done
+    allowed_files_json+="]"
+  fi
+
+  # Parse constraints array
+  local in_constraints=0
+  local constraints_array=()
+
+  while IFS= read -r line; do
+    # Check if we're at the constraints section
+    if [[ "$line" =~ ^constraints: ]]; then
+      in_constraints=1
+      continue
+    fi
+
+    # Exit constraints section when we hit a non-indented line
+    if [[ $in_constraints -eq 1 ]] && [[ "$line" =~ ^[a-z] ]]; then
+      in_constraints=0
+    fi
+
+    # Parse list items
+    if [[ $in_constraints -eq 1 && "$line" =~ ^[[:space:]]*-[[:space:]]+(.*) ]]; then
+      local constraint_text="${BASH_REMATCH[1]}"
+      if [[ -n "$constraint_text" ]]; then
+        # Escape quotes for JSON
+        constraint_text="${constraint_text//\\/\\\\}"
+        constraint_text="${constraint_text//\"/\\\"}"
+        constraints_array+=("\"$constraint_text\"")
+      fi
+    fi
+  done <<< "$frontmatter"
+
+  # Build constraints JSON
+  if [[ ${#constraints_array[@]} -gt 0 ]]; then
+    constraints_json="["
+    for i in "${!constraints_array[@]}"; do
+      constraints_json+="${constraints_array[$i]}"
+      if [[ $i -lt $((${#constraints_array[@]} - 1)) ]]; then
+        constraints_json+=","
+      fi
+    done
+    constraints_json+="]"
+  fi
+
+  # Output as JSON
+  jq -n \
+    --arg enforcement "$enforcement" \
+    --argjson allowed_files "$allowed_files_json" \
+    --argjson constraints "$constraints_json" \
+    '{enforcement: $enforcement, allowed_files: $allowed_files, constraints: $constraints}'
+}
+
+# task_get_spec_path <task_id> <artifact_dir>
+# Returns the path to the task spec file with zero-padded ID.
+task_get_spec_path() {
+  local task_id="$1"
+  local artifact_dir="$2"
+
+  local padded_id
+  padded_id=$(printf "%02d" "$task_id")
+
+  echo "${artifact_dir}/tasks/task-${padded_id}.md"
+}
+
+# task_read_runtime_overrides <task_id>
+# Reads the runtime overrides file (.qrspi/task-{NN}-runtime.json).
+# This file holds mid-task user decisions: approved extra files,
+# enforcement mode switches. See enforcement.sh for how it's consumed.
+# Returns 1 if not found.
+task_read_runtime_overrides() {
+  local task_id="$1"
+
+  local padded_id
+  padded_id=$(printf "%02d" "$task_id")
+
+  local overrides_path=".qrspi/task-${padded_id}-runtime.json"
+
+  if [[ ! -f "$overrides_path" ]]; then
+    return 1
+  fi
+
+  cat "$overrides_path"
+}
+
+# task_write_runtime_overrides <task_id> <json_string>
+# Writes the runtime overrides file (.qrspi/task-{NN}-runtime.json)
+# atomically (temp file + mv). Creates .qrspi/ if needed.
+task_write_runtime_overrides() {
+  local task_id="$1"
+  local json_string="$2"
+
+  local padded_id
+  padded_id=$(printf "%02d" "$task_id")
+
+  # Create .qrspi directory if needed
+  mkdir -p .qrspi
+
+  local overrides_path=".qrspi/task-${padded_id}-runtime.json"
+  # Write to temp file on the same filesystem so mv is atomic
+  # (cross-filesystem mv degrades to copy+delete, not atomic)
+  local temp_file
+  temp_file=$(mktemp ".qrspi/.task-${padded_id}-runtime.json.XXXXXX")
+
+  printf "%s" "$json_string" > "$temp_file"
+  mv "$temp_file" "$overrides_path"
+}

--- a/hooks/lib/validate.sh
+++ b/hooks/lib/validate.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source state.sh from the same directory (which transitively sources frontmatter.sh)
+_validate_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+source "$_validate_script_dir/state.sh"
+
+# validate_state_schema <artifact_dir>
+# Checks and repairs .qrspi/state.json:
+# - No state file → calls state_init_or_reconcile(), outputs "Created state.json from artifacts"
+# - Missing version field (v0) → rebuilds via state_init_or_reconcile(), outputs "Migrated state.json from v0 to v1"
+# - v1 with all fields → returns 0, no output
+# - v1 missing wireframe_requested → adds it as false, outputs "Repaired: added wireframe_requested"
+# - v1 missing active_task → adds it as null, outputs "Repaired: added active_task"
+# - v1 missing artifacts map → rebuilds, outputs "Repaired: rebuilt artifacts from frontmatter"
+# - Uses atomic write for all repairs
+validate_state_schema() {
+  local artifact_dir="$1"
+
+  # Check if state file exists
+  if [[ ! -f ".qrspi/state.json" ]]; then
+    # No state file - create from artifacts
+    state_init_or_reconcile "$artifact_dir"
+    echo "Created state.json from artifacts"
+    return 0
+  fi
+
+  # Read current state
+  local json
+  json=$(state_read)
+
+  # Check for version field
+  local has_version
+  has_version=$(echo "$json" | jq 'has("version")' 2>/dev/null || echo "false")
+
+  if [[ "$has_version" == "false" ]]; then
+    # v0 migration - rebuild via state_init_or_reconcile
+    state_init_or_reconcile "$artifact_dir"
+    echo "Migrated state.json from v0 to v1"
+    return 0
+  fi
+
+  # At this point we have version field, check for other required fields
+  local needs_repair=false
+  local repair_msgs=()
+
+  # Check for wireframe_requested
+  local has_wireframe
+  has_wireframe=$(echo "$json" | jq 'has("wireframe_requested")' 2>/dev/null || echo "false")
+  if [[ "$has_wireframe" == "false" ]]; then
+    needs_repair=true
+    repair_msgs+=("Repaired: added wireframe_requested")
+    json=$(echo "$json" | jq -c '.wireframe_requested = false')
+  fi
+
+  # Check for active_task
+  local has_active_task
+  has_active_task=$(echo "$json" | jq 'has("active_task")' 2>/dev/null || echo "false")
+  if [[ "$has_active_task" == "false" ]]; then
+    needs_repair=true
+    repair_msgs+=("Repaired: added active_task")
+    json=$(echo "$json" | jq -c '.active_task = null')
+  fi
+
+  # Check for artifacts map
+  local has_artifacts
+  has_artifacts=$(echo "$json" | jq 'has("artifacts")' 2>/dev/null || echo "false")
+  if [[ "$has_artifacts" == "false" ]]; then
+    needs_repair=true
+    repair_msgs+=("Repaired: rebuilt artifacts from frontmatter")
+
+    # Rebuild artifacts from frontmatter
+    local goals_status="draft"
+    local questions_status="draft"
+    local research_status="draft"
+    local design_status="draft"
+    local structure_status="draft"
+    local plan_status="draft"
+    local implement_status="draft"
+    local test_status="draft"
+
+    if [[ -f "$artifact_dir/goals.md" ]]; then
+      goals_status=$(frontmatter_get_status "$artifact_dir/goals.md" || echo "draft")
+    fi
+    if [[ -f "$artifact_dir/questions.md" ]]; then
+      questions_status=$(frontmatter_get_status "$artifact_dir/questions.md" || echo "draft")
+    fi
+    if [[ -f "$artifact_dir/research/summary.md" ]]; then
+      research_status=$(frontmatter_get_status "$artifact_dir/research/summary.md" || echo "draft")
+    fi
+    if [[ -f "$artifact_dir/design.md" ]]; then
+      design_status=$(frontmatter_get_status "$artifact_dir/design.md" || echo "draft")
+    fi
+    if [[ -f "$artifact_dir/structure.md" ]]; then
+      structure_status=$(frontmatter_get_status "$artifact_dir/structure.md" || echo "draft")
+    fi
+    if [[ -f "$artifact_dir/plan.md" ]]; then
+      plan_status=$(frontmatter_get_status "$artifact_dir/plan.md" || echo "draft")
+    fi
+
+    json=$(echo "$json" | jq -c \
+      --arg goals "$goals_status" \
+      --arg questions "$questions_status" \
+      --arg research "$research_status" \
+      --arg design "$design_status" \
+      --arg structure "$structure_status" \
+      --arg plan "$plan_status" \
+      --arg implement "$implement_status" \
+      --arg test "$test_status" \
+      '.artifacts = {
+        goals: $goals,
+        questions: $questions,
+        research: $research,
+        design: $design,
+        structure: $structure,
+        plan: $plan,
+        implement: $implement,
+        test: $test
+      }')
+  fi
+
+  # If repairs were made, write atomically and output messages
+  if [[ "$needs_repair" == true ]]; then
+    state_write_atomic "$json"
+    for msg in "${repair_msgs[@]}"; do
+      echo "$msg"
+    done
+  fi
+
+  return 0
+}
+
+# validate_config <config_path>
+# Checks config.md for required Phase 4 fields:
+# - All fields present → returns 0, no output
+# - Missing Phase 4 fields (enforcement_default) → adds defaults, outputs field names, returns 0
+# - Config doesn't exist → returns 1
+# - Preserves existing content when adding defaults
+validate_config() {
+  local config_path="$1"
+
+  # Check if config exists
+  if [[ ! -f "$config_path" ]]; then
+    return 1
+  fi
+
+  # Read the file
+  local content
+  content=$(cat "$config_path")
+
+  # Find the closing --- line (frontmatter must start with ---)
+  local frontmatter_end=0
+  local line_num=0
+  local first_line_is_separator=false
+
+  while IFS= read -r line; do
+    line_num=$((line_num + 1))
+    if [[ $line_num -eq 1 ]]; then
+      [[ "$line" == "---" ]] && first_line_is_separator=true
+      continue
+    fi
+    if [[ "$first_line_is_separator" == true ]] && [[ "$line" == "---" ]]; then
+      frontmatter_end=$line_num
+      break
+    fi
+  done <<< "$content"
+
+  # If no valid frontmatter, add it with defaults and re-read
+  if [[ $frontmatter_end -eq 0 ]]; then
+    local existing_content
+    existing_content=$(cat "$config_path")
+    printf -- '---\nenforcement_default: strict\n---\n%s' "$existing_content" > "$config_path"
+    echo "config.md: added missing frontmatter with enforcement_default: strict"
+    return 0
+  fi
+
+  # Extract frontmatter section (lines 2 through closing_line-1)
+  local fm_section
+  fm_section=$(sed -n '2,'$((frontmatter_end - 1))'p' "$config_path")
+
+  # Check for enforcement_default field
+  if ! echo "$fm_section" | grep -q "enforcement_default"; then
+    # Need to add enforcement_default
+    # Insert before the closing --- line
+    local before_closing
+    before_closing=$(head -n $((frontmatter_end - 1)) "$config_path")
+
+    local after_closing
+    after_closing=$(tail -n +$frontmatter_end "$config_path")
+
+    # Reconstruct file
+    local new_content="$before_closing
+enforcement_default: strict
+$after_closing"
+
+    echo "$new_content" > "$config_path"
+    echo "enforcement_default"
+  fi
+
+  return 0
+}
+
+# validate_task_specs <artifact_dir>
+# Read-only scan of task specs:
+# - All Phase 4 fields present → returns 0, no output
+# - Missing enforcement/allowed_files/constraints → returns 0, outputs warnings
+# - No task files → returns 0, no output
+# - Never modifies task files
+# - Always returns 0
+validate_task_specs() {
+  local artifact_dir="$1"
+
+  # Find all task-NN.md files
+  local task_files
+  task_files=$(find "$artifact_dir/tasks" -maxdepth 1 -name "task-*.md" -type f 2>/dev/null | sort || true)
+
+  # If no task files, return 0 with no output
+  if [[ -z "$task_files" ]]; then
+    return 0
+  fi
+
+  # Check each task file for required Phase 4 fields
+  local warnings=()
+  while IFS= read -r task_file; do
+    [[ -z "$task_file" ]] && continue
+
+    # Read the first 20 lines to extract frontmatter
+    local frontmatter_section=""
+    local line_num=0
+    local in_frontmatter=false
+    local found_closing=false
+
+    while IFS= read -r line && [[ $line_num -lt 20 ]]; do
+      line_num=$((line_num + 1))
+
+      if [[ $line_num -eq 1 ]] && [[ "$line" == "---" ]]; then
+        in_frontmatter=true
+        continue
+      fi
+
+      if [[ "$in_frontmatter" == true ]]; then
+        if [[ "$line" == "---" ]]; then
+          found_closing=true
+          break
+        fi
+        frontmatter_section+="$line"$'\n'
+      fi
+    done < "$task_file"
+
+    # Skip if no valid frontmatter
+    [[ "$found_closing" != true ]] && continue
+
+    # Check for enforcement field
+    if ! echo "$frontmatter_section" | grep -q "^enforcement:"; then
+      warnings+=("$(basename "$task_file"): missing enforcement")
+    fi
+
+    # Check for allowed_files field
+    if ! echo "$frontmatter_section" | grep -q "^allowed_files:"; then
+      warnings+=("$(basename "$task_file"): missing allowed_files")
+    fi
+
+    # Check for constraints field
+    if ! echo "$frontmatter_section" | grep -q "^constraints:"; then
+      warnings+=("$(basename "$task_file"): missing constraints")
+    fi
+  done <<< "$task_files"
+
+  # Output all warnings
+  for warning in "${warnings[@]}"; do
+    echo "$warning"
+  done
+
+  return 0
+}

--- a/hooks/lib/worktree.sh
+++ b/hooks/lib/worktree.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+worktree_is_inside() {
+  local cwd="$1"
+  local target_path="$2"
+
+  # Append / to cwd to avoid prefix matching issues
+  cwd="${cwd}/"
+
+  [[ "$target_path" == "$cwd"* ]]
+}
+
+worktree_detect() {
+  local cwd="$1"
+  [[ "$cwd" == *"/.worktrees/"* ]]
+}
+
+worktree_extract_task_id() {
+  local path="$1"
+
+  if [[ $path =~ \.worktrees/task-([0-9]+)(/|$) ]]; then
+    local task_num="${BASH_REMATCH[1]}"
+    # Strip leading zeros
+    echo "$((10#$task_num))"
+    return 0
+  fi
+
+  return 1
+}

--- a/hooks/post-tool-use
+++ b/hooks/post-tool-use
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# PostToolUse hook for QRSPI plugin
+# Responsibilities:
+#   1. Artifact state sync — for Write/Edit targeting known artifacts
+#   2. Audit logging — for ALL Write/Edit/Bash calls
+# Always exits 0 (non-blocking, async).
+#
+# NEVER SILENT: All errors and unexpected conditions are logged to both
+# stderr (user sees in diagnostics) and .qrspi/errors.log (persistent
+# record that survives session scrollback). Non-blocking does not mean silent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Source libraries
+source "$PLUGIN_ROOT/hooks/lib/artifact.sh"  # transitively gets pipeline, state, frontmatter
+source "$PLUGIN_ROOT/hooks/lib/audit.sh"     # transitively gets task
+source "$PLUGIN_ROOT/hooks/lib/enforcement.sh"
+source "$PLUGIN_ROOT/hooks/lib/bash-detect.sh"
+source "$PLUGIN_ROOT/hooks/lib/worktree.sh"
+
+# Log errors to stderr + audit trail.
+# When task_id is known, writes to audit-task-NN.jsonl (same file as normal audit).
+# When task_id is unknown, writes to audit.jsonl.
+# Both use JSONL format so the audit trail is one consistent format.
+log_error() {
+  local msg="$1"
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown")
+  echo "post-tool-use: ${msg}" >&2
+  mkdir -p .qrspi 2>/dev/null || true
+  local audit_file=".qrspi/audit.jsonl"
+  if [[ -n "${task_id:-}" ]]; then
+    local padded_id
+    padded_id=$(printf "%02d" "$task_id" 2>/dev/null || echo "00")
+    audit_file=".qrspi/audit-task-${padded_id}.jsonl"
+  fi
+  local error_json
+  error_json=$(jq -cn --arg ts "$timestamp" --arg msg "$msg" --arg tool "${tool_name:-unknown}" \
+    '{timestamp: $ts, tool: $tool, error: $msg}') 2>/dev/null || true
+  if [[ -n "$error_json" ]]; then
+    echo "$error_json" >> "$audit_file" 2>/dev/null || true
+  fi
+}
+
+# Read stdin
+stdin_json=$(cat)
+
+# Parse tool_name
+tool_name=$(printf '%s' "$stdin_json" | jq -r '.tool_name // empty' 2>/dev/null) || {
+  log_error "ERROR: malformed JSON on stdin — audit logging skipped for this tool call"
+  exit 0
+}
+if [[ -z "$tool_name" ]]; then
+  log_error "ERROR: missing tool_name in stdin JSON — audit logging skipped for this tool call"
+  exit 0
+fi
+
+# Only process Write, Edit, Bash — other tools don't need audit or state sync
+if [[ "$tool_name" != "Write" && "$tool_name" != "Edit" && "$tool_name" != "Bash" ]]; then
+  exit 0
+fi
+
+# Read state — if missing, no QRSPI project is active yet.
+# State is created by the QRSPI skills (Goals, using-qrspi) when they set
+# up the artifact directory. Hooks only read state, they don't create it.
+# Pre-tool-use already allows writes when state is missing (no pipeline to
+# enforce), so post-tool-use can safely skip artifact sync and audit logging
+# until the skills bootstrap state.
+state_json=$(state_read 2>/dev/null) || {
+  # No state file, or state file unreadable. If the file exists but can't
+  # be read, that's an error worth surfacing (vs simply "no project active").
+  if [[ -f ".qrspi/state.json" ]]; then
+    log_error "ERROR: state.json exists but cannot be read — audit logging skipped for ${tool_name} call"
+  fi
+  exit 0
+}
+artifact_dir=$(printf '%s' "$state_json" | jq -r '.artifact_dir // empty' 2>/dev/null) || {
+  log_error "WARNING: cannot parse artifact_dir from state — artifact sync and audit logging skipped for ${tool_name} call"
+  exit 0
+}
+if [[ -z "$artifact_dir" ]]; then
+  log_error "WARNING: artifact_dir is empty in state — artifact sync and audit logging skipped for ${tool_name} call"
+  exit 0
+fi
+
+# Resolve task ID
+task_id=""
+if worktree_detect "$PWD" 2>/dev/null; then
+  task_id=$(worktree_extract_task_id "$PWD" 2>/dev/null) || {
+    log_error "WARNING: in worktree but cannot extract task ID from path: ${PWD} — audit logging skipped"
+  }
+fi
+if [[ -z "$task_id" ]]; then
+  task_id=$(printf '%s' "$state_json" | jq -r '.active_task.id // empty' 2>/dev/null) || {
+    log_error "WARNING: cannot read active_task.id from state — audit logging skipped for ${tool_name} call"
+  }
+fi
+
+# Extract file_path or command
+file_path=""
+command_str=""
+if [[ "$tool_name" == "Bash" ]]; then
+  command_str=$(printf '%s' "$stdin_json" | jq -r '.tool_input.command // empty' 2>/dev/null) || {
+    log_error "WARNING: cannot parse command from Bash tool input"
+  }
+else
+  file_path=$(printf '%s' "$stdin_json" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || {
+    log_error "WARNING: cannot parse file_path from ${tool_name} tool input"
+  }
+fi
+
+# --- 1. Artifact state sync (Write/Edit only) ---
+if [[ -n "$file_path" ]]; then
+  step_name=$(artifact_is_known "$file_path" "$artifact_dir" 2>/dev/null) || true
+  if [[ -n "$step_name" ]]; then
+    if ! artifact_sync_state "$file_path" "$artifact_dir" 2>/dev/null; then
+      log_error "ERROR: artifact_sync_state failed for ${step_name} (${file_path}) — state.json may be stale"
+    fi
+  fi
+fi
+
+# --- 2. Audit logging ---
+if [[ -n "$task_id" ]]; then
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  # Determine enforcement mode and in_scope
+  enforcement="strict"
+  in_scope="true"
+  user_approved="false"
+
+  enforcement=$(enforcement_get_mode "$task_id" "$artifact_dir" 2>/dev/null) || {
+    log_error "WARNING: cannot determine enforcement mode for task ${task_id} — defaulting to strict"
+    enforcement="strict"
+  }
+
+  if [[ "$tool_name" == "Bash" ]]; then
+    # For Bash: detect file-write targets
+    targets=""
+    if [[ -n "$command_str" ]]; then
+      targets=$(bash_detect_file_writes "$command_str" 2>/dev/null) || {
+        log_error "WARNING: bash_detect_file_writes failed for command — logging with empty targets"
+      }
+    fi
+
+    if [[ -n "$targets" ]]; then
+      # Build targets JSON array using jq for proper escaping
+      targets_json=$(printf '%s' "$targets" | jq -R -s 'split("\n") | map(select(length > 0))')
+
+      # Use first target as primary
+      primary_target=$(printf '%s' "$targets" | head -1)
+
+      # Check in_scope for primary target
+      if enforcement_check_allowlist "$primary_target" "$task_id" "$artifact_dir" >/dev/null 2>&1; then
+        in_scope="true"
+      else
+        in_scope="false"
+      fi
+    else
+      targets_json='[]'
+      primary_target=""
+      in_scope="true"  # No targets = not out of scope
+    fi
+
+    if ! audit_log_operation "$task_id" "$timestamp" "Bash" "${primary_target:-}" "$targets_json" "$command_str" "$in_scope" "$enforcement" "$user_approved" "null"; then
+      log_error "ERROR: audit_log_operation failed for Bash call — audit trail has a gap"
+    fi
+  else
+    # Write/Edit
+    targets_json=$(jq -cn --arg p "$file_path" '[$p]')
+
+    # Check in_scope
+    if enforcement_check_allowlist "$file_path" "$task_id" "$artifact_dir" >/dev/null 2>&1; then
+      in_scope="true"
+    else
+      in_scope="false"
+    fi
+
+    if ! audit_log_operation "$task_id" "$timestamp" "$tool_name" "$file_path" "$targets_json" "null" "$in_scope" "$enforcement" "$user_approved" "null"; then
+      log_error "ERROR: audit_log_operation failed for ${tool_name} ${file_path} — audit trail has a gap"
+    fi
+  fi
+elif [[ "$tool_name" == "Write" || "$tool_name" == "Edit" || "$tool_name" == "Bash" ]]; then
+  # We have a Write/Edit/Bash call but no task ID — this is normal during
+  # non-implementation steps (Goals, Questions, etc.). Not an error, but
+  # worth noting if we're in a worktree (where task ID should always exist).
+  if worktree_detect "$PWD" 2>/dev/null; then
+    log_error "WARNING: in worktree but no task ID resolved — ${tool_name} call not audited"
+  fi
+fi
+
+exit 0

--- a/hooks/pre-tool-use
+++ b/hooks/pre-tool-use
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# PreToolUse hook for QRSPI plugin
+# Enforces pipeline step ordering by blocking writes to pipeline artifacts
+# when prerequisite steps are not yet approved.
+# Also enforces L1 (allowlist) and worktree containment checks.
+#
+# FAIL-CLOSED: When enforcement state cannot be determined (missing state file,
+# corrupted data, etc.), the hook BLOCKS and tells the user what's wrong.
+# The only exception is stdin parsing (Claude Code's responsibility) and
+# tools we don't enforce (Read, Glob, etc.).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Source pipeline library (which transitively sources state.sh and frontmatter.sh)
+source "$PLUGIN_ROOT/hooks/lib/pipeline.sh"
+
+# Source enforcement and supporting libraries
+source "$PLUGIN_ROOT/hooks/lib/enforcement.sh"
+source "$PLUGIN_ROOT/hooks/lib/bash-detect.sh"
+source "$PLUGIN_ROOT/hooks/lib/worktree.sh"
+source "$PLUGIN_ROOT/hooks/lib/protected.sh"
+
+# ── JSON escape helper ───────────────────────────────────────────────────────
+escape_for_json() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+block_with_reason() {
+  local reason="$1"
+  local reason_escaped
+  reason_escaped=$(escape_for_json "$reason")
+  echo "pre-tool-use: BLOCKED: ${reason}" >&2
+  printf '{"decision":"block","reason":"%s"}\n' "$reason_escaped"
+  exit 2
+}
+
+# ── Read stdin ───────────────────────────────────────────────────────────────
+stdin_json=$(cat)
+
+# ── Parse tool_name ──────────────────────────────────────────────────────────
+# FAIL-CLOSED: if we can't parse stdin, block — don't silently allow unknown operations
+tool_name=$(printf '%s' "$stdin_json" | jq -r '.tool_name // empty' 2>/dev/null) || {
+  block_with_reason "Cannot parse tool call: malformed JSON on stdin. This may indicate a Claude Code bug — report if persistent."
+}
+
+if [[ -z "$tool_name" ]]; then
+  block_with_reason "Cannot parse tool call: missing tool_name field. This may indicate a Claude Code bug — report if persistent."
+fi
+
+# ── Route by tool type ───────────────────────────────────────────────────────
+# Write/Edit: extract file_path for pipeline + enforcement checks
+# Bash: will check file-write targets for enforcement later
+# Other: pass through (we don't enforce Read, Glob, etc.)
+
+file_path=""
+is_bash_tool=0
+
+if [[ "$tool_name" == "Write" || "$tool_name" == "Edit" ]]; then
+  # FAIL-CLOSED: if we can't determine the target file, block
+  file_path=$(printf '%s' "$stdin_json" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || {
+    block_with_reason "Cannot parse ${tool_name} target: malformed tool_input. This may indicate a Claude Code bug — report if persistent."
+  }
+
+  if [[ -z "$file_path" ]]; then
+    block_with_reason "Cannot parse ${tool_name} target: missing file_path. This may indicate a Claude Code bug — report if persistent."
+  fi
+elif [[ "$tool_name" == "Bash" ]]; then
+  is_bash_tool=1
+else
+  # Not a tool we enforce
+  printf '{}\n'
+  exit 0
+fi
+
+# ── Pipeline ordering check (Write/Edit only) ────────────────────────────────
+if [[ $is_bash_tool -eq 0 ]]; then
+  # Map file_path suffix to pipeline step
+  # (order matters: research/summary.md before *.md)
+  artifact_step=""
+
+  if [[ "$file_path" == */research/summary.md ]]; then
+    artifact_step="research"
+  elif [[ "$file_path" == */goals.md ]]; then
+    artifact_step="goals"
+  elif [[ "$file_path" == */questions.md ]]; then
+    artifact_step="questions"
+  elif [[ "$file_path" == */design.md ]]; then
+    artifact_step="design"
+  elif [[ "$file_path" == */structure.md ]]; then
+    artifact_step="structure"
+  elif [[ "$file_path" == */plan.md ]]; then
+    artifact_step="plan"
+  fi
+
+  if [[ -n "$artifact_step" ]]; then
+    # Read state for pipeline check.
+    # If state file doesn't exist, skip the ordering check — there's no
+    # pipeline to enforce against. State is created by the QRSPI skills
+    # (Goals, using-qrspi) when they initialize the artifact directory.
+    # If state file EXISTS but is unreadable/corrupted, BLOCK — that's an
+    # error, not a bootstrap condition.
+    if [[ ! -f ".qrspi/state.json" ]]; then
+      printf '{}\n'
+      exit 0
+    fi
+    state_json=$(state_read 2>/dev/null) || {
+      block_with_reason "Cannot verify pipeline ordering: state file exists but is unreadable. Check .qrspi/state.json permissions or delete to reinitialize."
+    }
+
+    # Extract artifact_dir from state — FAIL-CLOSED if corrupted
+    artifact_dir=$(printf '%s' "$state_json" | jq -r '.artifact_dir // empty' 2>/dev/null) || {
+      block_with_reason "Cannot verify pipeline ordering: state file corrupted. Run SessionStart or /compact to reinitialize."
+    }
+
+    if [[ -z "$artifact_dir" ]]; then
+      block_with_reason "Cannot verify pipeline ordering: artifact_dir missing from state. Run SessionStart or /compact to reinitialize."
+    fi
+
+    missing_step=$(pipeline_check_prerequisites "$artifact_step" "$artifact_dir" 2>/dev/null) || {
+      # pipeline_check_prerequisites returned non-zero — missing_step is set on stdout
+      artifact_basename=$(basename "$file_path")
+
+      reason="Complete and approve ${missing_step} before writing ${artifact_basename}"
+      block_with_reason "$reason"
+    }
+  fi
+fi
+
+# ── Resolve task ID ───────────────────────────────────────────────────────────
+task_id=""
+
+if worktree_detect "$PWD"; then
+  # In a worktree — extract task ID from path. FAIL-CLOSED: worktree without
+  # identifiable task ID means we can't determine enforcement rules.
+  task_id=$(worktree_extract_task_id "$PWD" 2>/dev/null) || {
+    block_with_reason "Cannot determine task ID from worktree path: ${PWD}. Worktree directory must contain a task identifier."
+  }
+else
+  # Not in a worktree — read from state file.
+  # If state file doesn't exist, no enforcement context (normal for early steps).
+  # If state file exists but is unreadable, block — same principle as pipeline check.
+  if [[ -f ".qrspi/state.json" ]]; then
+    state_json_for_task=$(state_read 2>/dev/null) || {
+      block_with_reason "Cannot read state file for task enforcement. Check .qrspi/state.json permissions or delete to reinitialize."
+    }
+    task_id=$(printf '%s' "$state_json_for_task" | jq -r '.active_task.id // empty' 2>/dev/null) || true
+  fi
+  # No task_id outside a worktree is normal (e.g., during Goals/Questions steps
+  # before implementation). Enforcement checks below only run when task_id is set.
+fi
+
+# ── Write/Edit-specific enforcement checks ───────────────────────────────────
+if [[ $is_bash_tool -eq 0 ]]; then
+
+  # -- Worktree containment check --
+  if worktree_detect "$PWD"; then
+    if ! worktree_is_inside "$PWD" "$file_path"; then
+      block_with_reason "Worktree containment violation: target file is outside the worktree boundary"
+    fi
+  fi
+
+  # -- Protected path check --
+  # Compute is_worktree flag: 0 = in worktree, 1 = not in worktree
+  if worktree_detect "$PWD"; then
+    is_worktree_flag=0
+  else
+    is_worktree_flag=1
+  fi
+
+  # Compute relative path from file_path
+  rel_file_path="$file_path"
+  if [[ "$file_path" == /* ]]; then
+    cwd_with_slash="${PWD}/"
+    if [[ "$file_path" == "$cwd_with_slash"* ]]; then
+      rel_file_path="${file_path#"${cwd_with_slash}"}"
+    fi
+  fi
+
+  if protected_is_blocked "$rel_file_path" "$is_worktree_flag"; then
+    block_with_reason "Protected path: ${rel_file_path} cannot be modified from a worktree"
+  fi
+
+  # -- L1 allowlist check (only if we have a task ID) --
+  if [[ -n "$task_id" ]]; then
+    # Need artifact_dir for enforcement check — read state if not already read
+    if [[ -z "${artifact_dir:-}" ]]; then
+      state_for_enf=$(state_read 2>/dev/null) || {
+        block_with_reason "Cannot verify file allowlist: state file missing. Run SessionStart or /compact to initialize."
+      }
+      artifact_dir=$(printf '%s' "$state_for_enf" | jq -r '.artifact_dir // empty' 2>/dev/null) || {
+        block_with_reason "Cannot verify file allowlist: state file corrupted. Run SessionStart or /compact to reinitialize."
+      }
+    fi
+
+    # FAIL-CLOSED: if we have a task ID but can't resolve artifact_dir, block
+    if [[ -z "${artifact_dir:-}" ]]; then
+      block_with_reason "Cannot verify file allowlist: artifact_dir missing from state. Run SessionStart or /compact to reinitialize."
+    fi
+
+    if ! enforcement_check_allowlist "$file_path" "$task_id" "$artifact_dir" 2>/dev/null; then
+      reason="File not in allowlist for task ${task_id}. Options: 1) Ask user to approve 2) Switch to monitored 3) Find alternative"
+      block_with_reason "$reason"
+    fi
+  fi
+
+fi
+
+# ── Bash file-write target enforcement ───────────────────────────────────────
+if [[ $is_bash_tool -eq 1 && -n "$task_id" ]]; then
+  bash_command=$(printf '%s' "$stdin_json" | jq -r '.tool_input.command // empty' 2>/dev/null) || true
+
+  if [[ -n "${bash_command:-}" ]]; then
+    # Need artifact_dir — read state if not already available
+    if [[ -z "${artifact_dir:-}" ]]; then
+      state_for_bash=$(state_read 2>/dev/null) || {
+        block_with_reason "Cannot verify bash file-write targets: state file missing. Run SessionStart or /compact to initialize."
+      }
+      artifact_dir=$(printf '%s' "$state_for_bash" | jq -r '.artifact_dir // empty' 2>/dev/null) || {
+        block_with_reason "Cannot verify bash file-write targets: state file corrupted. Run SessionStart or /compact to reinitialize."
+      }
+    fi
+
+    # FAIL-CLOSED: if we have a task ID but can't resolve artifact_dir, block
+    if [[ -z "${artifact_dir:-}" ]]; then
+      block_with_reason "Cannot verify bash file-write targets: artifact_dir missing from state. Run SessionStart or /compact to reinitialize."
+    fi
+
+    targets=$(bash_detect_file_writes "$bash_command" 2>/dev/null) || true
+
+    if [[ -n "${targets:-}" ]]; then
+      while IFS= read -r target; do
+        [[ -z "$target" ]] && continue
+        if ! enforcement_check_allowlist "$target" "$task_id" "$artifact_dir" 2>/dev/null; then
+          reason="File not in allowlist for task ${task_id}: ${target}. Options: 1) Ask user to approve 2) Switch to monitored 3) Find alternative"
+          block_with_reason "$reason"
+        fi
+      done <<< "$targets"
+    fi
+  fi
+fi
+
+# All checks passed — allow
+printf '{}\n'
+exit 0

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # SessionStart hook for QRSPI plugin
-# Reads using-qrspi skill and injects it into conversation context
+# Injects the using-qrspi skill content into conversation context.
+#
+# This hook does NOT initialize state or validate artifacts — that is the
+# responsibility of pipeline skills (which know which project they're working
+# on). Skills create state via state_init_or_reconcile; hooks only read it.
 
 set -euo pipefail
 

--- a/hooks/setup-project-hooks.sh
+++ b/hooks/setup-project-hooks.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# setup-project-hooks.sh
+# TEMPORARY WORKAROUND for Claude Code bug #17688: plugin-level hooks
+# (registered in hooks.json) may not fire for subagent tool calls. This
+# script copies hook registrations into a project's .claude/settings.json
+# where they fire for all tool calls including subagents.
+#
+# WHY THIS EXISTS:
+#   Plugin hooks should fire for all agents in the session (main + subagents).
+#   Bug #17688 causes them to only fire for the main session. This script
+#   works around the bug by duplicating the registrations at project level.
+#
+# WHEN TO REMOVE:
+#   Once bug #17688 is confirmed fixed, this script is no longer needed.
+#   To verify: run a QRSPI pipeline with enforcement hooks registered ONLY
+#   at plugin level (hooks.json), dispatch a worktree subagent, and confirm
+#   PreToolUse blocks fire for the subagent's tool calls. If they do, the
+#   bug is fixed and this script can be deleted.
+#
+# CLEANUP AFTER REMOVAL:
+#   Projects that ran this script have QRSPI hooks hardcoded in their
+#   .claude/settings.json. To clean up: run this script's remove_qrspi
+#   jq function on the project's settings, or manually delete the
+#   PreToolUse/PostToolUse entries whose commands contain the QRSPI
+#   plugin path. The idempotent merge logic means leftover entries
+#   won't conflict — they'll just be orphaned command paths.
+#
+# KNOWN LIMITATION:
+#   The project settings get hardcoded absolute paths to the plugin
+#   install location (e.g., ~/.claude/plugins/cache/qrspi-local/...).
+#   If the plugin version changes or the cache path moves, re-run this
+#   script to update the paths. Plugin-level hooks use ${CLAUDE_PLUGIN_ROOT}
+#   which is expanded by Claude Code at runtime — project-level hooks
+#   don't support this variable, hence the hardcoded paths.
+#
+# Usage: setup-project-hooks.sh [PROJECT_DIR]
+#   PROJECT_DIR  target project directory (default: $PWD)
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOKS_JSON="$PLUGIN_ROOT/hooks/hooks.json"
+
+# Exit 1 if hooks.json is missing
+if [[ ! -f "$HOOKS_JSON" ]]; then
+  echo "ERROR: hooks.json not found at $HOOKS_JSON" >&2
+  exit 1
+fi
+
+TARGET_DIR="${1:-$PWD}"
+SETTINGS_DIR="$TARGET_DIR/.claude"
+SETTINGS_FILE="$SETTINGS_DIR/settings.json"
+
+# Ensure .claude directory exists
+mkdir -p "$SETTINGS_DIR"
+
+# Read PreToolUse and PostToolUse from hooks.json, replacing ${CLAUDE_PLUGIN_ROOT}
+# with the actual absolute PLUGIN_ROOT path
+QRSPI_PRE=$(jq --arg root "$PLUGIN_ROOT" \
+  '[.hooks.PreToolUse[] | .hooks[].command |= gsub("\\$\\{CLAUDE_PLUGIN_ROOT\\}"; $root) | .]' \
+  "$HOOKS_JSON")
+
+QRSPI_POST=$(jq --arg root "$PLUGIN_ROOT" \
+  '[.hooks.PostToolUse[] | .hooks[].command |= gsub("\\$\\{CLAUDE_PLUGIN_ROOT\\}"; $root) | .]' \
+  "$HOOKS_JSON")
+
+# Build or load the current settings JSON
+if [[ -f "$SETTINGS_FILE" ]]; then
+  CURRENT=$(jq '.' "$SETTINGS_FILE")
+else
+  CURRENT='{}'
+fi
+
+# Merge QRSPI hooks idempotently:
+#   For each event type (PreToolUse, PostToolUse):
+#     - Remove any existing entries whose command contains the PLUGIN_ROOT path
+#       (so re-running replaces rather than duplicates)
+#     - Append the QRSPI entries
+MERGED=$(jq \
+  --arg root "$PLUGIN_ROOT" \
+  --argjson qrspi_pre "$QRSPI_PRE" \
+  --argjson qrspi_post "$QRSPI_POST" \
+  '
+  # Helper: remove existing QRSPI entries from an array based on plugin root
+  def remove_qrspi(root):
+    if . == null then [] else
+      map(select(
+        (.hooks // []) | map(.command // "") | map(test(root; "g")) | any | not
+      ))
+    end;
+
+  # Merge PreToolUse
+  .hooks.PreToolUse = ((.hooks.PreToolUse // []) | remove_qrspi($root)) + $qrspi_pre |
+
+  # Merge PostToolUse
+  .hooks.PostToolUse = ((.hooks.PostToolUse // []) | remove_qrspi($root)) + $qrspi_post
+  ' \
+  <<< "$CURRENT")
+
+# Write result atomically: write to temp file first, then rename.
+# mv is atomic on POSIX — prevents a crash mid-write from leaving
+# a half-written settings.json that would break Claude Code.
+TMP_FILE=$(mktemp "$SETTINGS_DIR/.settings.json.XXXXXX")
+printf '%s\n' "$MERGED" | jq '.' > "$TMP_FILE"
+mv "$TMP_FILE" "$SETTINGS_FILE"
+
+echo "QRSPI hooks written to $SETTINGS_FILE (PreToolUse: $(jq '.hooks.PreToolUse | length' "$SETTINGS_FILE"), PostToolUse: $(jq '.hooks.PostToolUse | length' "$SETTINGS_FILE"))"

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -229,6 +229,10 @@ status: approved
 task: NN
 phase: {phase number}
 pipeline: full
+# Optional Phase 4 enforcement fields (deferred to T24 for full schema):
+# enforcement: strict
+# allowed_files: [...]
+# constraints: [...]
 ---
 
 # Task NN: {name}
@@ -262,6 +266,23 @@ Fix tasks are stored in `fixes/{type}-round-NN/` and follow the same format as r
 
 - `plan.md` — complete plan with overview + all task specs (review artifact), overview-only after approval
 - `tasks/task-NN.md` — individual task specs split out after approval (implementation artifacts)
+
+### `.qrspi/` Directory
+
+The artifact directory contains a `.qrspi/` subdirectory managed by hooks (not by this skill):
+
+- `state.json` — pipeline state cache (current step, approved artifacts, `phase_start_commit`)
+- `task-NN-runtime.json` — per-task runtime overrides: user mid-task decisions like approved extra files and enforcement mode switches (written by hooks during implementation)
+- `audit-task-NN.jsonl` — per-task audit logs (written by hooks during implementation)
+
+**This directory is created and managed by hooks.** The Plan skill does not need to create, update, or read files in `.qrspi/`.
+
+**State management is deterministic and hook-driven:**
+- The SessionStart hook initializes and reconciles `state.json` from artifact frontmatter at the start of each session
+- The PostToolUse hook syncs `state.json` automatically whenever artifact frontmatter changes (e.g., when `status: approved` is written)
+- Skills do NOT need to update `state.json` when artifacts are approved — the hook handles this
+
+**Exception — `phase_start_commit`:** The Plan skill writes `phase_start_commit` directly to `state.json` when `plan.md` is approved. This records the current HEAD hash as the diff boundary for post-integration reviews. The Plan skill is the only skill that writes to state directly; all other state updates are hook-driven.
 
 ### Terminal State
 

--- a/skills/using-qrspi/SKILL.md
+++ b/skills/using-qrspi/SKILL.md
@@ -134,24 +134,28 @@ docs/qrspi/YYYY-MM-DD-{slug}/
 │   └── test-round-01/
 ├── feedback/
 │   └── ...
-└── reviews/
-    ├── goals-review.md
-    ├── questions-review.md
-    ├── research-review.md
-    ├── design-review.md
-    ├── structure-review.md
-    ├── plan-review.md
-    ├── replan-review.md
-    ├── baseline-failures.md       (Worktree baseline)
-    ├── tasks/
-    │   └── ...
-    ├── integration/
-    │   └── round-NN-review.md
-    ├── ci/
-    │   └── round-NN-review.md
-    └── test/
-        ├── round-NN-review.md
-        └── baseline-failures.md   (Test baseline)
+├── reviews/
+│   ├── goals-review.md
+│   ├── questions-review.md
+│   ├── research-review.md
+│   ├── design-review.md
+│   ├── structure-review.md
+│   ├── plan-review.md
+│   ├── replan-review.md
+│   ├── baseline-failures.md       (Worktree baseline)
+│   ├── tasks/
+│   │   └── ...
+│   ├── integration/
+│   │   └── round-NN-review.md
+│   ├── ci/
+│   │   └── round-NN-review.md
+│   └── test/
+│       ├── round-NN-review.md
+│       └── baseline-failures.md   (Test baseline)
+└── .qrspi/                        (hook-managed, do not edit manually)
+    ├── state.json                 (pipeline state cache)
+    ├── task-NN-runtime.json       (per-task runtime overrides — user mid-task decisions)
+    └── audit-task-NN.jsonl        (per-task audit logs)
 ```
 
 The slug is generated during the Goals step: take the user's first description, extract 2-4 key words, convert to lowercase kebab-case (e.g., "user-auth", "product-search-api").
@@ -185,7 +189,20 @@ status: approved
 
 **Status values:** `draft` (initial), `approved` (user-approved), `replan-draft` (transient — used during Replan's minor path re-approval cycle; artifact gating treats this the same as `draft`, so downstream skills correctly refuse to proceed until re-approval completes).
 
+**Writing `status: approved` is sufficient.** The PostToolUse hook detects the frontmatter change and updates `state.json` automatically. Skills do not need to perform any explicit state update after writing the approval marker.
+
 **Commit after approval.** Every approved artifact (and its review file) should be committed to git immediately after the approval marker is written. This preserves the approved state as a checkpoint the user can return to. Use a descriptive commit message like `docs(qrspi): approve {step} for {project-slug}`. Do not batch approvals across steps — commit each step's approval separately.
+
+## Hook-Managed State (`.qrspi/`)
+
+The `.qrspi/` directory inside each artifact directory is created and maintained entirely by hooks:
+
+- **SessionStart hook** — initializes `state.json` at the start of each session by reconciling it against artifact frontmatter on disk (handles interrupted sessions and out-of-sync state)
+- **PostToolUse hook** — keeps `state.json` in sync whenever an artifact's frontmatter changes
+
+Skills do not need to create, read, or update any file in `.qrspi/`. State is always current when a skill needs it because the hooks maintain it continuously.
+
+**Pipeline enforcement:** PreToolUse hooks enforce pipeline step ordering. Attempting to write a downstream artifact (e.g., `design.md`) before its prerequisites are approved will be blocked by the hook. Pipeline progression is code-enforced, not just prompt-enforced.
 
 ## Rejection Behavior
 

--- a/tests/acceptance/test-audit-logging.bats
+++ b/tests/acceptance/test-audit-logging.bats
@@ -1,0 +1,442 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Acceptance tests for Criterion 2 — Audit Logging portion:
+# "Audit logging: PostToolUse logs all Write/Edit/Bash operations to
+#  .qrspi/audit-task-NN.jsonl"
+#
+# These tests drive the post-tool-use hook end-to-end and verify:
+#   - Write/Edit operations are logged when a task is active
+#   - Bash operations with file-write patterns are logged
+#   - Log entries are valid JSONL with all required fields
+#   - Strict vs monitored in_scope flag is set correctly
+#   - Special characters in commands/paths do not corrupt JSON
+#   - No logging when no task is active (no task ID in state)
+#
+# Regression: audit.sh uses jq --arg for all string fields (no shell interpolation)
+
+setup() {
+  export WORK_DIR
+  WORK_DIR=$(mktemp -d)
+  export ARTIFACT_DIR="$WORK_DIR/artifacts"
+  mkdir -p "$ARTIFACT_DIR/tasks"
+  mkdir -p "$WORK_DIR/.qrspi"
+  cd "$WORK_DIR"
+
+  export HOOK
+  HOOK="$(dirname "$BATS_TEST_FILENAME")/../../hooks/post-tool-use"
+}
+
+teardown() {
+  rm -rf "$WORK_DIR"
+}
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+create_task_spec() {
+  local task_num="$1"
+  local enforcement="${2:-monitored}"
+  shift 2
+  local allowed_block=""
+  for p in "$@"; do
+    allowed_block="${allowed_block}  - action: create\n    path: ${p}\n"
+  done
+  printf -- '---\nstatus: approved\ntask: %s\nphase: 1\nenforcement: %s\nallowed_files:\n%s\nconstraints: []\n---\n\n# Task %s\n' \
+    "$task_num" "$enforcement" "$(printf '%b' "$allowed_block")" "$task_num" \
+    > "$ARTIFACT_DIR/tasks/task-$(printf '%02d' "$task_num").md"
+}
+
+init_state_with_task() {
+  local task_id="$1"
+  local abs_artifact_dir
+  abs_artifact_dir="$(cd "$ARTIFACT_DIR" && pwd)"
+  jq -cn --arg artifact_dir "$abs_artifact_dir" --argjson task_id "$task_id" \
+    '{version:1,current_step:"implement",phase_start_commit:null,
+      artifact_dir:$artifact_dir,wireframe_requested:false,
+      artifacts:{goals:"approved",questions:"approved",research:"approved",
+                 design:"approved",structure:"approved",plan:"approved",
+                 implement:"draft",test:"draft"},
+      active_task:{id:$task_id}}' > "$WORK_DIR/.qrspi/state.json"
+}
+
+init_state_no_task() {
+  local abs_artifact_dir
+  abs_artifact_dir="$(cd "$ARTIFACT_DIR" && pwd)"
+  jq -cn --arg artifact_dir "$abs_artifact_dir" \
+    '{version:1,current_step:"plan",phase_start_commit:null,
+      artifact_dir:$artifact_dir,wireframe_requested:false,
+      artifacts:{goals:"approved",questions:"approved",research:"approved",
+                 design:"approved",structure:"approved",plan:"draft",
+                 implement:"draft",test:"draft"},
+      active_task:null}' > "$WORK_DIR/.qrspi/state.json"
+}
+
+write_json() {
+  local file_path="$1"
+  printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}\n' "$file_path"
+}
+
+edit_json() {
+  local file_path="$1"
+  printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"a","new_string":"b"}}\n' "$file_path"
+}
+
+bash_json() {
+  local cmd="$1"
+  local escaped_cmd="${cmd//\\/\\\\}"
+  escaped_cmd="${escaped_cmd//\"/\\\"}"
+  printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}\n' "$escaped_cmd"
+}
+
+audit_file_for_task() {
+  local task_id="$1"
+  printf '%s/.qrspi/audit-task-%02d.jsonl' "$WORK_DIR" "$task_id"
+}
+
+# ── Basic logging presence ────────────────────────────────────────────────────
+
+# AC2 — Write operation is logged when task is active
+@test "[AC2][audit] Write operation creates audit log entry → JSONL file exists" {
+  create_task_spec 1 "monitored"
+  init_state_with_task 1
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  [ -f "$(audit_file_for_task 1)" ]
+}
+
+# AC2 — Edit operation is logged when task is active
+@test "[AC2][audit] Edit operation creates audit log entry" {
+  create_task_spec 2 "monitored"
+  init_state_with_task 2
+
+  "$HOOK" <<< "$(edit_json "$WORK_DIR/src/file.sh")"
+
+  [ -f "$(audit_file_for_task 2)" ]
+}
+
+# AC2 — Bash operation is logged when task is active and has file-write targets
+@test "[AC2][audit] Bash with file-write target creates audit log entry" {
+  create_task_spec 3 "monitored"
+  init_state_with_task 3
+
+  "$HOOK" <<< "$(bash_json "echo data > out.txt")"
+
+  [ -f "$(audit_file_for_task 3)" ]
+}
+
+# AC2 — Multiple operations produce multiple JSONL lines
+@test "[AC2][audit] Multiple Write operations produce multiple JSONL lines" {
+  create_task_spec 4 "monitored"
+  init_state_with_task 4
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/a.sh")"
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/b.sh")"
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/c.sh")"
+
+  local line_count
+  line_count=$(wc -l < "$(audit_file_for_task 4)")
+  [ "$line_count" -eq 3 ]
+}
+
+# ── JSONL record validity ─────────────────────────────────────────────────────
+
+# AC2 — Each log line is valid JSON
+@test "[AC2][audit] Each audit log line is valid JSON (parseable by jq)" {
+  create_task_spec 5 "monitored"
+  init_state_with_task 5
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  run jq '.' "$(audit_file_for_task 5)"
+  [ "$status" -eq 0 ]
+}
+
+# AC2 — Log entry has all required fields
+@test "[AC2][audit] Write log entry has all required fields: timestamp, tool, target, targets, command, in_scope, enforcement, user_approved, destructive_flag" {
+  create_task_spec 6 "monitored"
+  init_state_with_task 6
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 6)")
+
+  local has_all
+  has_all=$(echo "$record" | jq '
+    has("timestamp") and
+    has("tool") and
+    has("target") and
+    has("targets") and
+    has("command") and
+    has("in_scope") and
+    has("enforcement") and
+    has("user_approved") and
+    has("destructive_flag")')
+  [ "$has_all" = "true" ]
+}
+
+# AC2 — Write log entry: tool field is "Write"
+@test "[AC2][audit] Write log entry tool field = 'Write'" {
+  create_task_spec 7 "monitored"
+  init_state_with_task 7
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 7)")
+  [ "$(echo "$record" | jq -r '.tool')" = "Write" ]
+}
+
+# AC2 — Edit log entry: tool field is "Edit"
+@test "[AC2][audit] Edit log entry tool field = 'Edit'" {
+  create_task_spec 8 "monitored"
+  init_state_with_task 8
+
+  "$HOOK" <<< "$(edit_json "$WORK_DIR/src/file.sh")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 8)")
+  [ "$(echo "$record" | jq -r '.tool')" = "Edit" ]
+}
+
+# AC2 — Write log entry: command field is JSON null (not string "null")
+@test "[AC2][audit] Write log entry command field is JSON null" {
+  create_task_spec 9 "monitored"
+  init_state_with_task 9
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 9)")
+  [ "$(echo "$record" | jq '.command')" = "null" ]
+}
+
+# AC2 — Write log entry: target field matches file_path
+@test "[AC2][audit] Write log entry target field matches written file_path" {
+  create_task_spec 10 "monitored"
+  init_state_with_task 10
+
+  local target_path="$WORK_DIR/src/myfile.sh"
+  "$HOOK" <<< "$(write_json "$target_path")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 10)")
+  [ "$(echo "$record" | jq -r '.target')" = "$target_path" ]
+}
+
+# AC2 — Write log entry: targets is a JSON array
+@test "[AC2][audit] Write log entry targets field is a JSON array" {
+  create_task_spec 11 "monitored"
+  init_state_with_task 11
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 11)")
+  [ "$(echo "$record" | jq '.targets | type')" = '"array"' ]
+}
+
+# AC2 — Write log entry: timestamp is ISO 8601 format
+@test "[AC2][audit] Write log entry timestamp is ISO 8601 format" {
+  create_task_spec 12 "monitored"
+  init_state_with_task 12
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 12)")
+  local ts
+  ts=$(echo "$record" | jq -r '.timestamp')
+  # ISO 8601: YYYY-MM-DDTHH:MM:SSZ
+  [[ "$ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+# AC2 — in_scope is a JSON boolean, not a string
+@test "[AC2][audit] Log entry in_scope field is a JSON boolean (not string)" {
+  create_task_spec 13 "monitored"
+  init_state_with_task 13
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 13)")
+  [ "$(echo "$record" | jq '.in_scope | type')" = '"boolean"' ]
+}
+
+# ── in_scope flag: strict vs monitored ──────────────────────────────────────
+
+# AC2 — Strict mode: write to allowed file → in_scope=true
+@test "[AC2][audit] Strict mode write to allowed file → in_scope=true in log" {
+  create_task_spec 14 "strict" "src/allowed.sh"
+  init_state_with_task 14
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/allowed.sh")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 14)")
+  [ "$(echo "$record" | jq '.in_scope')" = "true" ]
+}
+
+# AC2 — Strict mode: write to non-allowed file → in_scope=false in log
+# (post-tool-use always logs; pre-tool-use would have blocked this, but post logs after the fact)
+@test "[AC2][audit] Strict mode write to non-allowed file → in_scope=false in log" {
+  create_task_spec 15 "strict" "src/allowed.sh"
+  init_state_with_task 15
+
+  # Post hook logs regardless of whether pre blocked it — test log accuracy
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/not-allowed.sh")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 15)")
+  [ "$(echo "$record" | jq '.in_scope')" = "false" ]
+}
+
+# AC2 — Monitored mode: write to any file → in_scope=true in log
+@test "[AC2][audit] Monitored mode write → in_scope=true in log" {
+  create_task_spec 16 "monitored"
+  init_state_with_task 16
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/any-file.sh")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 16)")
+  [ "$(echo "$record" | jq '.in_scope')" = "true" ]
+}
+
+# AC2 — enforcement field in log matches task spec
+@test "[AC2][audit] Log entry enforcement field matches task spec mode" {
+  create_task_spec 17 "strict" "src/file.sh"
+  init_state_with_task 17
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 17)")
+  [ "$(echo "$record" | jq -r '.enforcement')" = "strict" ]
+}
+
+# ── No logging when no task is active ────────────────────────────────────────
+
+# AC2 — No task active → no audit file created
+@test "[AC2][audit] No active task → no audit file created" {
+  init_state_no_task
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  # No audit file should exist
+  local audit_glob
+  audit_glob=$(ls "$WORK_DIR/.qrspi/audit-task-"*.jsonl 2>/dev/null || true)
+  [ -z "$audit_glob" ]
+}
+
+# ── Bash tool logging ─────────────────────────────────────────────────────────
+
+# AC2 — Bash with file-write: log entry tool field is "Bash"
+@test "[AC2][audit] Bash log entry tool field = 'Bash'" {
+  create_task_spec 18 "monitored"
+  init_state_with_task 18
+
+  "$HOOK" <<< "$(bash_json "echo data > out.txt")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 18)")
+  [ "$(echo "$record" | jq -r '.tool')" = "Bash" ]
+}
+
+# AC2 — Bash log entry: command field is set (not null)
+@test "[AC2][audit] Bash log entry command field is not null" {
+  create_task_spec 19 "monitored"
+  init_state_with_task 19
+
+  "$HOOK" <<< "$(bash_json "echo data > out.txt")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 19)")
+  # command must be a string, not null
+  [ "$(echo "$record" | jq '.command | type')" = '"string"' ]
+}
+
+# ── Regression: JSON escaping ─────────────────────────────────────────────────
+
+# AC2 (regression) — Command with double-quotes is properly JSON-escaped
+# Pre-fix: shell interpolation in audit.sh broke on quotes
+@test "[AC2][audit][regression] Command with double-quotes is properly JSON-escaped" {
+  create_task_spec 20 "monitored"
+  init_state_with_task 20
+
+  # Use bash_json helper which escapes the command for the hook's stdin JSON
+  "$HOOK" <<< "$(bash_json 'grep "pattern" file.txt > out.txt')"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 20)")
+  # Record must be valid JSON (no corruption from quotes)
+  echo "$record" | jq . > /dev/null
+  local cmd
+  cmd=$(echo "$record" | jq -r '.command')
+  [[ "$cmd" == *'"pattern"'* ]] || [[ "$cmd" == *"pattern"* ]]
+}
+
+# AC2 (regression) — Target path with special characters is properly JSON-escaped
+@test "[AC2][audit][regression] Target path with backslash is properly JSON-escaped" {
+  create_task_spec 21 "monitored"
+  init_state_with_task 21
+
+  # Write to a file with a tricky path component (trailing period)
+  local tricky_path="$WORK_DIR/src/my.file.sh"
+  "$HOOK" <<< "$(write_json "$tricky_path")"
+
+  local record
+  record=$(head -1 "$(audit_file_for_task 21)")
+  # Record must be valid JSON
+  echo "$record" | jq . > /dev/null
+  [ "$(echo "$record" | jq -r '.target')" = "$tricky_path" ]
+}
+
+# ── Post-tool-use always exits 0 (non-blocking) ──────────────────────────────
+
+# AC2 — Post hook exits 0 for Write
+@test "[AC2][audit] post-tool-use always exits 0 for Write" {
+  create_task_spec 22 "monitored"
+  init_state_with_task 22
+
+  run "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+  [ "$status" -eq 0 ]
+}
+
+# AC2 — Post hook exits 0 for Bash
+@test "[AC2][audit] post-tool-use always exits 0 for Bash" {
+  create_task_spec 23 "monitored"
+  init_state_with_task 23
+
+  run "$HOOK" <<< "$(bash_json "ls -la")"
+  [ "$status" -eq 0 ]
+}
+
+# AC2 — Post hook exits 0 for malformed JSON (fail-open)
+@test "[AC2][audit] post-tool-use exits 0 on malformed JSON (fail-open)" {
+  run "$HOOK" <<< "not valid json"
+  [ "$status" -eq 0 ]
+}
+
+# ── Audit file naming ─────────────────────────────────────────────────────────
+
+# AC2 — Audit file for task 3 is audit-task-03.jsonl (zero-padded)
+@test "[AC2][audit] Audit file for task 3 uses zero-padded name audit-task-03.jsonl" {
+  create_task_spec 3 "monitored"
+  init_state_with_task 3
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  [ -f "$WORK_DIR/.qrspi/audit-task-03.jsonl" ]
+}
+
+# AC2 — Audit file for task 15 is audit-task-15.jsonl
+@test "[AC2][audit] Audit file for task 15 uses name audit-task-15.jsonl" {
+  create_task_spec 15 "monitored"
+  init_state_with_task 15
+
+  "$HOOK" <<< "$(write_json "$WORK_DIR/src/file.sh")"
+
+  [ -f "$WORK_DIR/.qrspi/audit-task-15.jsonl" ]
+}

--- a/tests/acceptance/test-enforcement.bats
+++ b/tests/acceptance/test-enforcement.bats
@@ -1,0 +1,447 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Acceptance tests for Criterion 2 — Enforcement (non-audit portions):
+# "During implementation, file writes outside the plan's allowlist are either
+#  blocked (strict mode) or logged for post-task audit (monitored mode)"
+#
+# Covers:
+#   - Strict mode allowlist blocking via Write/Edit tools
+#   - Monitored mode: writes allowed regardless of allowlist
+#   - Bash tool file-write detection (>, sed -i, cp, mv, tee patterns)
+#   - Worktree containment: blocks writes outside worktree boundary
+#   - Protected paths: blocks task spec, state.json, config from worktree agents
+#   - Approve/switch/reject interaction model hints in block message
+#
+# Tests operate end-to-end through the pre-tool-use hook.
+
+setup() {
+  export WORK_DIR
+  WORK_DIR=$(mktemp -d)
+  export ARTIFACT_DIR="$WORK_DIR/artifacts"
+  mkdir -p "$ARTIFACT_DIR/tasks"
+  mkdir -p "$WORK_DIR/.qrspi"
+  cd "$WORK_DIR"
+
+  export HOOK
+  HOOK="$(dirname "$BATS_TEST_FILENAME")/../../hooks/pre-tool-use"
+}
+
+teardown() {
+  rm -rf "$WORK_DIR"
+}
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+create_task_spec() {
+  local task_num="$1"
+  local enforcement="$2"
+  shift 2
+  # Remaining args are allowed file paths (relative)
+  local allowed_block=""
+  for p in "$@"; do
+    allowed_block="${allowed_block}  - action: create\n    path: ${p}\n"
+  done
+  printf -- '---\nstatus: approved\ntask: %s\nphase: 1\nenforcement: %s\nallowed_files:\n%s\nconstraints: []\n---\n\n# Task %s\n' \
+    "$task_num" "$enforcement" "$(printf '%b' "$allowed_block")" "$task_num" \
+    > "$ARTIFACT_DIR/tasks/task-$(printf '%02d' "$task_num").md"
+}
+
+# Initialise state with a given active_task id (no pipeline artifacts needed for enforcement tests)
+init_state_with_task() {
+  local task_id="$1"
+  local abs_artifact_dir
+  abs_artifact_dir="$(cd "$ARTIFACT_DIR" && pwd)"
+  jq -cn \
+    --arg version "1" \
+    --arg artifact_dir "$abs_artifact_dir" \
+    --argjson task_id "$task_id" \
+    '{version:1, current_step:"implement", phase_start_commit:null,
+      artifact_dir:$artifact_dir, wireframe_requested:false,
+      artifacts:{goals:"approved",questions:"approved",research:"approved",
+                 design:"approved",structure:"approved",plan:"approved",
+                 implement:"draft",test:"draft"},
+      active_task:{id:$task_id}}' > "$WORK_DIR/.qrspi/state.json"
+}
+
+write_json() {
+  local file_path="$1"
+  printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}\n' "$file_path"
+}
+
+edit_json() {
+  local file_path="$1"
+  printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"a","new_string":"b"}}\n' "$file_path"
+}
+
+bash_json() {
+  local cmd="$1"
+  # Escape backslashes and double quotes for inline JSON
+  local escaped_cmd="${cmd//\\/\\\\}"
+  escaped_cmd="${escaped_cmd//\"/\\\"}"
+  printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}\n' "$escaped_cmd"
+}
+
+# ── Criterion 2: Strict mode Write/Edit allowlist ────────────────────────────
+
+# AC2 — Strict mode: file in allowed_files is allowed
+@test "[AC2][strict] Write to allowed file in strict mode → exit 0" {
+  create_task_spec 1 "strict" "src/main.sh"
+  init_state_with_task 1
+
+  run "$HOOK" <<< "$(write_json "$WORK_DIR/src/main.sh")"
+  [ "$status" -eq 0 ]
+}
+
+# AC2 — Strict mode: file NOT in allowed_files is blocked
+@test "[AC2][strict] Write to file not in allowed_files in strict mode → exit 2" {
+  create_task_spec 2 "strict" "src/main.sh"
+  init_state_with_task 2
+
+  run "$HOOK" <<< "$(write_json "$WORK_DIR/src/other.sh")"
+  [ "$status" -eq 2 ]
+  [[ "$(echo "${lines[-1]}" | jq -r '.decision')" == "block" ]]
+}
+
+# AC2 — Strict mode: Edit to file NOT in allowed_files is blocked
+@test "[AC2][strict] Edit to file not in allowed_files in strict mode → exit 2" {
+  create_task_spec 3 "strict" "src/main.sh"
+  init_state_with_task 3
+
+  run "$HOOK" <<< "$(edit_json "$WORK_DIR/src/not-allowed.sh")"
+  [ "$status" -eq 2 ]
+  [[ "$(echo "${lines[-1]}" | jq -r '.decision')" == "block" ]]
+}
+
+# AC2 — Strict mode block message includes approve/switch/reject interaction hints
+@test "[AC2][strict] Block message mentions approve, switch, reject interaction options" {
+  create_task_spec 4 "strict" "src/main.sh"
+  init_state_with_task 4
+
+  run "$HOOK" <<< "$(write_json "$WORK_DIR/src/unlisted.sh")"
+  [ "$status" -eq 2 ]
+  # The block reason must guide the agent on what to do
+  [[ "$output" == *"approve"* ]] || [[ "$output" == *"switch"* ]] || [[ "$output" == *"reject"* ]] || \
+    [[ "$output" == *"Ask user"* ]] || [[ "$output" == *"Options"* ]]
+}
+
+# ── Criterion 2: Runtime runtime overrides user_approved_files override ────────────────
+
+# AC2 — Strict mode: file in runtime overrides user_approved_files is allowed even if not in spec
+@test "[AC2][runtime overrides] File in user_approved_files runtime runtime overrides is allowed in strict mode → exit 0" {
+  create_task_spec 5 "strict" "src/main.sh"
+  init_state_with_task 5
+
+  # Write runtime overrides with extra approved file
+  printf '{"enforcement":"strict","user_approved_files":["src/extra.sh"]}' \
+    > "$WORK_DIR/.qrspi/task-05-runtime.json"
+
+  run "$HOOK" <<< "$(write_json "$WORK_DIR/src/extra.sh")"
+  [ "$status" -eq 0 ]
+}
+
+# AC2 — Sidecar enforcement=monitored overrides task spec strict
+@test "[AC2][runtime overrides] Sidecar enforcement=monitored overrides strict task spec → write allowed" {
+  create_task_spec 6 "strict" "src/main.sh"
+  init_state_with_task 6
+
+  printf '{"enforcement":"monitored","user_approved_files":[]}' \
+    > "$WORK_DIR/.qrspi/task-06-runtime.json"
+
+  # Write to a file that is not in the task spec's allowed_files
+  run "$HOOK" <<< "$(write_json "$WORK_DIR/src/anything.sh")"
+  [ "$status" -eq 0 ]
+}
+
+# ── Criterion 2: Monitored mode ──────────────────────────────────────────────
+
+# AC2 — Monitored mode: any file write is allowed
+@test "[AC2][monitored] Any file write allowed in monitored mode → exit 0" {
+  create_task_spec 7 "monitored"
+  init_state_with_task 7
+
+  run "$HOOK" <<< "$(write_json "$WORK_DIR/src/anything-at-all.sh")"
+  [ "$status" -eq 0 ]
+}
+
+# AC2 — Pre-Phase-4 task spec (no enforcement field) defaults to strict (fail-closed): blocks writes
+@test "[AC2][strict] Pre-Phase-4 task spec defaults to strict (fail-closed) → write blocked" {
+  # Task spec without enforcement/allowed_files/constraints (old format)
+  printf -- '---\nstatus: approved\ntask: 8\nphase: 1\n---\n\n# Task 8\n' \
+    > "$ARTIFACT_DIR/tasks/task-08.md"
+  init_state_with_task 8
+
+  run "$HOOK" <<< "$(write_json "$WORK_DIR/src/whatever.sh")"
+  [ "$status" -eq 2 ]
+}
+
+# ── Criterion 2: Bash tool file-write detection ──────────────────────────────
+
+# AC2 — Bash redirect (>) to allowed file in strict mode is allowed
+@test "[AC2][bash-detect] Bash redirect > to allowed file in strict mode → exit 0" {
+  create_task_spec 9 "strict" "out/result.txt"
+  init_state_with_task 9
+
+  run "$HOOK" <<< "$(bash_json "echo hello > out/result.txt")"
+  [ "$status" -eq 0 ]
+}
+
+# AC2 — Bash redirect (>) to non-allowed file in strict mode is blocked
+@test "[AC2][bash-detect] Bash redirect > to non-allowed file in strict mode → exit 2" {
+  create_task_spec 10 "strict" "out/result.txt"
+  init_state_with_task 10
+
+  run "$HOOK" <<< "$(bash_json "echo hello > out/forbidden.txt")"
+  [ "$status" -eq 2 ]
+  [[ "$(echo "${lines[-1]}" | jq -r '.decision')" == "block" ]]
+}
+
+# AC2 — Bash append (>>) to non-allowed file in strict mode is blocked
+@test "[AC2][bash-detect] Bash append >> to non-allowed file in strict mode → exit 2" {
+  create_task_spec 11 "strict" "out/result.txt"
+  init_state_with_task 11
+
+  run "$HOOK" <<< "$(bash_json "echo more >> out/forbidden.txt")"
+  [ "$status" -eq 2 ]
+}
+
+# AC2 — Bash tee to non-allowed file in strict mode is blocked
+@test "[AC2][bash-detect] Bash tee to non-allowed file in strict mode → exit 2" {
+  create_task_spec 12 "strict" "out/result.txt"
+  init_state_with_task 12
+
+  run "$HOOK" <<< "$(bash_json "cat data.txt | tee out/snapshot.txt")"
+  [ "$status" -eq 2 ]
+}
+
+# AC2 — Bash cp to non-allowed destination in strict mode is blocked
+@test "[AC2][bash-detect] Bash cp to non-allowed destination in strict mode → exit 2" {
+  create_task_spec 13 "strict" "out/result.txt"
+  init_state_with_task 13
+
+  run "$HOOK" <<< "$(bash_json "cp src.sh out/copy.sh")"
+  [ "$status" -eq 2 ]
+}
+
+# AC2 — Bash with no file-write patterns in strict mode is allowed
+@test "[AC2][bash-detect] Bash read-only command with no file writes in strict mode → exit 0" {
+  create_task_spec 14 "strict" "out/result.txt"
+  init_state_with_task 14
+
+  run "$HOOK" <<< "$(bash_json "cat file.txt && grep pattern file.txt")"
+  [ "$status" -eq 0 ]
+}
+
+# ── Criterion 2: Worktree containment ────────────────────────────────────────
+
+# AC2 — Inside a worktree: write to file inside worktree boundary is allowed
+@test "[AC2][worktree] Write inside worktree boundary → exit 0" {
+  create_task_spec 1 "monitored"
+  # Simulate a worktree CWD by creating a path that matches /.worktrees/ pattern
+  local worktree_dir
+  worktree_dir=$(mktemp -d "/tmp/project.XXXXXX")
+  mkdir -p "$worktree_dir/.worktrees/task-01"
+  mkdir -p "$worktree_dir/.worktrees/task-01/.qrspi"
+
+  # State in the worktree directory
+  local abs_artifact_dir
+  abs_artifact_dir="$(cd "$ARTIFACT_DIR" && pwd)"
+  jq -cn --arg artifact_dir "$abs_artifact_dir" \
+    '{version:1,current_step:"implement",phase_start_commit:null,
+      artifact_dir:$artifact_dir,wireframe_requested:false,
+      artifacts:{goals:"approved",questions:"approved",research:"approved",
+                 design:"approved",structure:"approved",plan:"approved",
+                 implement:"draft",test:"draft"},
+      active_task:{id:1}}' > "$worktree_dir/.worktrees/task-01/.qrspi/state.json"
+
+  # Run hook from within the worktree
+  local target_file="$worktree_dir/.worktrees/task-01/src/main.sh"
+  local json
+  json=$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}\n' "$target_file")
+
+  run bash -c "cd '$worktree_dir/.worktrees/task-01' && '$HOOK' <<< '$json'"
+  # Containment check: file is inside worktree, should be allowed
+  [ "$status" -eq 0 ]
+
+  rm -rf "$worktree_dir"
+}
+
+# AC2 — Inside a worktree: write to file outside worktree boundary is blocked
+@test "[AC2][worktree] Write outside worktree boundary → exit 2 with containment violation" {
+  # Create a worktree directory structure
+  local worktree_dir
+  worktree_dir=$(mktemp -d "/tmp/project.XXXXXX")
+  mkdir -p "$worktree_dir/.worktrees/task-02"
+  mkdir -p "$worktree_dir/.worktrees/task-02/.qrspi"
+  mkdir -p "$worktree_dir/.worktrees/task-02/artifacts/tasks"
+
+  local abs_artifact_dir="$worktree_dir/.worktrees/task-02/artifacts"
+  printf -- '---\nstatus:approved\ntask:2\nphase:1\nenforcement:monitored\nallowed_files:[]\nconstraints:[]\n---\n\n# Task 2\n' \
+    > "$abs_artifact_dir/tasks/task-02.md"
+
+  jq -cn --arg artifact_dir "$abs_artifact_dir" \
+    '{version:1,current_step:"implement",phase_start_commit:null,
+      artifact_dir:$artifact_dir,wireframe_requested:false,
+      artifacts:{goals:"approved",questions:"approved",research:"approved",
+                 design:"approved",structure:"approved",plan:"approved",
+                 implement:"draft",test:"draft"},
+      active_task:{id:2}}' > "$worktree_dir/.worktrees/task-02/.qrspi/state.json"
+
+  # Target is outside the worktree boundary — in parent project directory
+  local outside_file="$worktree_dir/main-project/hooks/lib/secret.sh"
+  local json
+  json=$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}\n' "$outside_file")
+
+  run bash -c "cd '$worktree_dir/.worktrees/task-02' && '$HOOK' <<< '$json'"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"containment"* ]] || [[ "$output" == *"outside"* ]] || [[ "$output" == *"boundary"* ]]
+
+  rm -rf "$worktree_dir"
+}
+
+# ── Criterion 2: Protected paths ─────────────────────────────────────────────
+
+# AC2 — Inside a worktree: writing to tasks/task-NN.md is blocked (protected)
+@test "[AC2][protected] Write to tasks/task-NN.md from worktree is blocked → exit 2" {
+  local worktree_dir
+  worktree_dir=$(mktemp -d "/tmp/project.XXXXXX")
+  mkdir -p "$worktree_dir/.worktrees/task-03"
+  mkdir -p "$worktree_dir/.worktrees/task-03/.qrspi"
+  mkdir -p "$worktree_dir/.worktrees/task-03/artifacts/tasks"
+
+  local abs_artifact_dir="$worktree_dir/.worktrees/task-03/artifacts"
+  printf -- '---\nstatus:approved\ntask:3\nphase:1\nenforcement:monitored\nallowed_files:[]\nconstraints:[]\n---\n\n# Task 3\n' \
+    > "$abs_artifact_dir/tasks/task-03.md"
+
+  jq -cn --arg artifact_dir "$abs_artifact_dir" \
+    '{version:1,current_step:"implement",phase_start_commit:null,
+      artifact_dir:$artifact_dir,wireframe_requested:false,
+      artifacts:{goals:"approved",questions:"approved",research:"approved",
+                 design:"approved",structure:"approved",plan:"approved",
+                 implement:"draft",test:"draft"},
+      active_task:{id:3}}' > "$worktree_dir/.worktrees/task-03/.qrspi/state.json"
+
+  # Target is the task spec file inside the worktree — protected path
+  local target_file="$worktree_dir/.worktrees/task-03/tasks/task-03.md"
+  local json
+  json=$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"tampered"}}\n' "$target_file")
+
+  run bash -c "cd '$worktree_dir/.worktrees/task-03' && '$HOOK' <<< '$json'"
+  [ "$status" -eq 2 ]
+  [[ "$(echo "${lines[-1]}" | jq -r '.decision')" == "block" ]]
+
+  rm -rf "$worktree_dir"
+}
+
+# AC2 — Inside a worktree: writing to .qrspi/state.json is blocked (protected)
+@test "[AC2][protected] Write to .qrspi/state.json from worktree is blocked → exit 2" {
+  local worktree_dir
+  worktree_dir=$(mktemp -d "/tmp/project.XXXXXX")
+  mkdir -p "$worktree_dir/.worktrees/task-04"
+  mkdir -p "$worktree_dir/.worktrees/task-04/.qrspi"
+  mkdir -p "$worktree_dir/.worktrees/task-04/artifacts/tasks"
+
+  local abs_artifact_dir="$worktree_dir/.worktrees/task-04/artifacts"
+  printf -- '---\nstatus:approved\ntask:4\nphase:1\nenforcement:monitored\nallowed_files:[]\nconstraints:[]\n---\n\n# Task 4\n' \
+    > "$abs_artifact_dir/tasks/task-04.md"
+
+  jq -cn --arg artifact_dir "$abs_artifact_dir" \
+    '{version:1,current_step:"implement",phase_start_commit:null,
+      artifact_dir:$artifact_dir,wireframe_requested:false,
+      artifacts:{goals:"approved",questions:"approved",research:"approved",
+                 design:"approved",structure:"approved",plan:"approved",
+                 implement:"draft",test:"draft"},
+      active_task:{id:4}}' > "$worktree_dir/.worktrees/task-04/.qrspi/state.json"
+
+  local target_file="$worktree_dir/.worktrees/task-04/.qrspi/state.json"
+  local json
+  json=$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"{}"}}\n' "$target_file")
+
+  run bash -c "cd '$worktree_dir/.worktrees/task-04' && '$HOOK' <<< '$json'"
+  [ "$status" -eq 2 ]
+  [[ "$(echo "${lines[-1]}" | jq -r '.decision')" == "block" ]]
+
+  rm -rf "$worktree_dir"
+}
+
+# AC2 — Inside a worktree: writing to config.md is blocked (protected)
+@test "[AC2][protected] Write to config.md from worktree is blocked → exit 2" {
+  local worktree_dir
+  worktree_dir=$(mktemp -d "/tmp/project.XXXXXX")
+  mkdir -p "$worktree_dir/.worktrees/task-05"
+  mkdir -p "$worktree_dir/.worktrees/task-05/.qrspi"
+  mkdir -p "$worktree_dir/.worktrees/task-05/artifacts/tasks"
+
+  local abs_artifact_dir="$worktree_dir/.worktrees/task-05/artifacts"
+  printf -- '---\nstatus:approved\ntask:5\nphase:1\nenforcement:monitored\nallowed_files:[]\nconstraints:[]\n---\n\n# Task 5\n' \
+    > "$abs_artifact_dir/tasks/task-05.md"
+
+  jq -cn --arg artifact_dir "$abs_artifact_dir" \
+    '{version:1,current_step:"implement",phase_start_commit:null,
+      artifact_dir:$artifact_dir,wireframe_requested:false,
+      artifacts:{goals:"approved",questions:"approved",research:"approved",
+                 design:"approved",structure:"approved",plan:"approved",
+                 implement:"draft",test:"draft"},
+      active_task:{id:5}}' > "$worktree_dir/.worktrees/task-05/.qrspi/state.json"
+
+  local target_file="$worktree_dir/.worktrees/task-05/config.md"
+  local json
+  json=$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"tampered"}}\n' "$target_file")
+
+  run bash -c "cd '$worktree_dir/.worktrees/task-05' && '$HOOK' <<< '$json'"
+  [ "$status" -eq 2 ]
+  [[ "$(echo "${lines[-1]}" | jq -r '.decision')" == "block" ]]
+
+  rm -rf "$worktree_dir"
+}
+
+# ── Regression: validate_task_specs searches artifact_dir/tasks/ ─────────────
+
+# AC2 (regression) — validate_task_specs must find files in artifact_dir/tasks/
+# not in artifact_dir/ (the pre-fix bug searched artifact_dir directly)
+@test "[AC2][regression] validate_task_specs correctly scans artifact_dir/tasks/ subdirectory" {
+  local validate_lib
+  validate_lib="$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/validate.sh"
+
+  local test_artifact_dir
+  test_artifact_dir=$(mktemp -d)
+  mkdir -p "$test_artifact_dir/tasks"
+
+  # Create a task spec ONLY in tasks/ subdirectory (not in artifact_dir root)
+  printf -- '---\ntitle: Old-style task\n---\n\n# Task 1\n' \
+    > "$test_artifact_dir/tasks/task-01.md"
+
+  # Source in bats context (avoids set -e + arithmetic exit code issue)
+  source "$validate_lib"
+
+  local output_str
+  output_str=$(validate_task_specs "$test_artifact_dir")
+
+  # The warning must be emitted (file found in tasks/ subdirectory)
+  [[ "$output_str" == *"task-01.md"* ]]
+
+  rm -rf "$test_artifact_dir"
+}
+
+# AC2 (regression) — validate_task_specs with task files only in artifact_dir root
+# should find NO tasks (regression: old code would never find any)
+@test "[AC2][regression] validate_task_specs ignores task files placed in artifact_dir root" {
+  local validate_lib
+  validate_lib="$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/validate.sh"
+
+  local test_artifact_dir
+  test_artifact_dir=$(mktemp -d)
+  # Place task file directly in root, NOT in tasks/ — should not be found
+  printf -- '---\ntitle: Misplaced task\n---\n\n# Task 1\n' \
+    > "$test_artifact_dir/task-01.md"
+
+  source "$validate_lib"
+
+  local output_str
+  output_str=$(validate_task_specs "$test_artifact_dir")
+
+  # No warnings expected — misplaced file is not in tasks/
+  [[ -z "$output_str" ]]
+
+  rm -rf "$test_artifact_dir"
+}

--- a/tests/acceptance/test-meta.bats
+++ b/tests/acceptance/test-meta.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Acceptance tests for Criterion 8.
+#
+# Criterion 8: "All existing pipeline functionality (Goals through Replan)
+#   continues to work after Phase 4 changes — validated by the 200 unit tests
+#   passing (baseline confirmed)."
+#   → Meta-test: confirm the unit test suite still has exactly 200 @test entries
+#     across exactly 12 .bats files.
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+unit_test_dir() {
+  echo "$(dirname "$BATS_TEST_DIRNAME")/unit"
+}
+
+# ── Criterion 8: Unit test suite baseline ────────────────────────────────────
+
+# AC8 — The unit test directory contains exactly 12 .bats files
+@test "[AC8] Unit test suite has exactly 12 .bats files (baseline)" {
+  local dir
+  dir="$(unit_test_dir)"
+  local count
+  count=$(find "$dir" -maxdepth 1 -name "*.bats" -type f | wc -l | tr -d ' ')
+  [ "$count" -eq 12 ]
+}
+
+# AC8 — Across all 12 unit test files, there are exactly 204 @test definitions
+@test "[AC8] Unit test suite has exactly 204 @test definitions (baseline)" {
+  local dir
+  dir="$(unit_test_dir)"
+  local count
+  count=$(grep -r "^@test" "$dir" --include="*.bats" | wc -l | tr -d ' ')
+  [ "$count" -eq 204 ]
+}
+
+# AC8 — Every expected unit test file is present by name
+@test "[AC8] All 12 expected unit test files are present by name" {
+  local dir
+  dir="$(unit_test_dir)"
+
+  local expected_files=(
+    "test-artifact.bats"
+    "test-audit.bats"
+    "test-bash-detect.bats"
+    "test-enforcement.bats"
+    "test-frontmatter.bats"
+    "test-pipeline.bats"
+    "test-pre-tool-use.bats"
+    "test-setup-project-hooks.bats"
+    "test-state.bats"
+    "test-task.bats"
+    "test-validate.bats"
+    "test-worktree.bats"
+  )
+
+  for f in "${expected_files[@]}"; do
+    [ -f "$dir/$f" ]
+  done
+}
+
+# AC8 — No unit test file is empty (each has at least one @test)
+@test "[AC8] No unit test file is empty (all have at least one @test)" {
+  local dir
+  dir="$(unit_test_dir)"
+
+  while IFS= read -r bats_file; do
+    local test_count
+    test_count=$(grep -c "^@test" "$bats_file" || true)
+    [ "$test_count" -gt 0 ]
+  done < <(find "$dir" -maxdepth 1 -name "*.bats" -type f | sort)
+}

--- a/tests/acceptance/test-pipeline-ordering.bats
+++ b/tests/acceptance/test-pipeline-ordering.bats
@@ -1,0 +1,311 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Acceptance tests for Criterion 1:
+# "Pipeline step ordering is enforced by code such that an agent structurally
+#  cannot skip or reorder steps without triggering a hard block"
+#
+# These tests operate end-to-end through the pre-tool-use hook script,
+# not individual library functions (those are covered by unit tests).
+
+setup() {
+  export ARTIFACT_DIR
+  ARTIFACT_DIR=$(mktemp -d)
+  export WORK_DIR
+  WORK_DIR=$(mktemp -d)
+  cd "$WORK_DIR"
+
+  mkdir -p "$ARTIFACT_DIR/research"
+
+  # Path to the hook under test
+  export HOOK
+  HOOK="$(dirname "$BATS_TEST_FILENAME")/../../hooks/pre-tool-use"
+}
+
+teardown() {
+  rm -rf "$ARTIFACT_DIR" "$WORK_DIR"
+}
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+create_artifact() {
+  local path="$1"
+  local status="$2"
+  mkdir -p "$(dirname "$path")"
+  printf -- '---\nstatus: %s\n---\nContent\n' "$status" > "$path"
+}
+
+# Bootstrap state.json by sourcing pipeline.sh and calling state_init_or_reconcile
+init_state() {
+  local artifact_dir="$1"
+  local pipeline_lib
+  pipeline_lib="$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/pipeline.sh"
+  bash -c "source '$pipeline_lib'; cd '$WORK_DIR'; state_init_or_reconcile '$artifact_dir'"
+}
+
+write_json() {
+  local file_path="$1"
+  printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"new"}}\n' "$file_path"
+}
+
+edit_json() {
+  local file_path="$1"
+  printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"old","new_string":"new"}}\n' "$file_path"
+}
+
+# Set up a "full draft" artifact layout (all steps exist but are draft)
+setup_full_draft() {
+  create_artifact "$ARTIFACT_DIR/goals.md"            "draft"
+  create_artifact "$ARTIFACT_DIR/questions.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact "$ARTIFACT_DIR/design.md"           "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md"             "draft"
+  init_state "$ARTIFACT_DIR"
+}
+
+# ── Criterion 1: Forward move requires previous step approved ────────────────
+
+# AC1 — Write to questions.md is blocked when goals is draft
+@test "[AC1] Write questions.md blocked when goals draft → exit 2 with 'goals' in reason" {
+  # goals is draft; questions write should require goals approved first
+  create_artifact "$ARTIFACT_DIR/goals.md"            "draft"
+  create_artifact "$ARTIFACT_DIR/questions.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact "$ARTIFACT_DIR/design.md"           "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md"             "draft"
+  init_state "$ARTIFACT_DIR"
+
+  run "$HOOK" <<< "$(write_json "$ARTIFACT_DIR/questions.md")"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"goals"* ]]
+}
+
+# AC1 — Write to design.md blocked when goals+questions approved but research draft
+@test "[AC1] Write design.md blocked when research not approved → exit 2 with 'research' in reason" {
+  create_artifact "$ARTIFACT_DIR/goals.md"            "approved"
+  create_artifact "$ARTIFACT_DIR/questions.md"        "approved"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact "$ARTIFACT_DIR/design.md"           "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md"             "draft"
+  init_state "$ARTIFACT_DIR"
+
+  run "$HOOK" <<< "$(write_json "$ARTIFACT_DIR/design.md")"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"research"* ]]
+}
+
+# AC1 — Write to structure.md blocked when design not approved
+@test "[AC1] Write structure.md blocked when design not approved → exit 2 with 'design' in reason" {
+  create_artifact "$ARTIFACT_DIR/goals.md"            "approved"
+  create_artifact "$ARTIFACT_DIR/questions.md"        "approved"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "approved"
+  create_artifact "$ARTIFACT_DIR/design.md"           "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md"             "draft"
+  init_state "$ARTIFACT_DIR"
+
+  run "$HOOK" <<< "$(edit_json "$ARTIFACT_DIR/structure.md")"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"design"* ]]
+}
+
+# AC1 — Write to plan.md blocked when structure not approved
+@test "[AC1] Write plan.md blocked when structure not approved → exit 2" {
+  create_artifact "$ARTIFACT_DIR/goals.md"            "approved"
+  create_artifact "$ARTIFACT_DIR/questions.md"        "approved"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "approved"
+  create_artifact "$ARTIFACT_DIR/design.md"           "approved"
+  create_artifact "$ARTIFACT_DIR/structure.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md"             "draft"
+  init_state "$ARTIFACT_DIR"
+
+  run "$HOOK" <<< "$(write_json "$ARTIFACT_DIR/plan.md")"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"structure"* ]]
+}
+
+# AC1 — Full pipeline approved: write to plan.md is allowed
+@test "[AC1] Write plan.md allowed when all prerequisites approved → exit 0" {
+  create_artifact "$ARTIFACT_DIR/goals.md"            "approved"
+  create_artifact "$ARTIFACT_DIR/questions.md"        "approved"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "approved"
+  create_artifact "$ARTIFACT_DIR/design.md"           "approved"
+  create_artifact "$ARTIFACT_DIR/structure.md"        "approved"
+  create_artifact "$ARTIFACT_DIR/plan.md"             "draft"
+  init_state "$ARTIFACT_DIR"
+
+  run "$HOOK" <<< "$(write_json "$ARTIFACT_DIR/plan.md")"
+  [ "$status" -eq 0 ]
+}
+
+# AC1 — goals is always allowed to write (no prerequisites)
+@test "[AC1] Write goals.md always allowed (first step, no prerequisites) → exit 0" {
+  setup_full_draft
+
+  run "$HOOK" <<< "$(write_json "$ARTIFACT_DIR/goals.md")"
+  [ "$status" -eq 0 ]
+}
+
+# AC1 — Skipping multiple steps is blocked (research when goals still draft)
+@test "[AC1] Attempting to skip to research.md with goals draft → exit 2" {
+  create_artifact "$ARTIFACT_DIR/goals.md"            "draft"
+  create_artifact "$ARTIFACT_DIR/questions.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact "$ARTIFACT_DIR/design.md"           "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md"             "draft"
+  init_state "$ARTIFACT_DIR"
+
+  run "$HOOK" <<< "$(write_json "$ARTIFACT_DIR/research/summary.md")"
+  [ "$status" -eq 2 ]
+  # Should mention the first missing prerequisite (goals)
+  [[ "$output" == *"goals"* ]]
+}
+
+# ── Criterion 1: Dual-check — frontmatter is source of truth ─────────────────
+
+# AC1 (dual-check) — Even if state.json says goals=approved, frontmatter draft → block
+@test "[AC1][dual-check] Frontmatter overrides state.json: goals draft in file blocks questions write" {
+  create_artifact "$ARTIFACT_DIR/goals.md"            "draft"
+  create_artifact "$ARTIFACT_DIR/questions.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact "$ARTIFACT_DIR/design.md"           "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md"             "draft"
+  init_state "$ARTIFACT_DIR"
+
+  # Manually patch state.json to lie and say goals is approved
+  local pipeline_lib
+  pipeline_lib="$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/pipeline.sh"
+  bash -c "
+    source '$pipeline_lib'
+    cd '$WORK_DIR'
+    s=\$(state_read)
+    s=\$(printf '%s' \"\$s\" | jq '.artifacts.goals = \"approved\"')
+    state_write_atomic \"\$s\"
+  "
+
+  # Hook must still block because frontmatter says draft
+  run "$HOOK" <<< "$(write_json "$ARTIFACT_DIR/questions.md")"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"goals"* ]]
+}
+
+# ── Criterion 1: Backward loops cascade reset downstream ─────────────────────
+
+# AC1 (backward loop) — Writing goals.md when questions was approved cascades reset downstream
+# We verify this by: all approved up through questions, then write goals.md succeeds,
+# then writing design.md is blocked (questions was cascade-reset to draft by the Write goals path)
+# NOTE: The hook allows the write itself (goals can always be written), but downstream state
+# reflects the cascade on the next call. We test that writing to design.md after re-writing
+# goals is blocked because a backward write to goals triggers cascade.
+@test "[AC1][backward-loop] Writing to goals.md (backward) then design.md is blocked" {
+  create_artifact "$ARTIFACT_DIR/goals.md"            "approved"
+  create_artifact "$ARTIFACT_DIR/questions.md"        "approved"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "approved"
+  create_artifact "$ARTIFACT_DIR/design.md"           "approved"
+  create_artifact "$ARTIFACT_DIR/structure.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md"             "draft"
+  init_state "$ARTIFACT_DIR"
+
+  # Downgrade goals.md on disk to draft (simulate user editing it)
+  create_artifact "$ARTIFACT_DIR/goals.md" "draft"
+
+  # Now design.md write should fail — goals is no longer approved
+  run "$HOOK" <<< "$(write_json "$ARTIFACT_DIR/design.md")"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"goals"* ]]
+}
+
+# ── Criterion 1: Non-artifact writes are always allowed ───────────────────────
+
+# AC1 — Writing to a file outside the pipeline does not trigger ordering checks
+@test "[AC1] Write to non-artifact source file is always allowed → exit 0" {
+  setup_full_draft  # all draft, but goals.md is the current step
+
+  # Writing to a random source file should not be blocked by pipeline ordering
+  run "$HOOK" <<< '{"tool_name":"Write","tool_input":{"file_path":"/tmp/some-impl-file.sh","content":"#!/bin/bash"}}'
+  [ "$status" -eq 0 ]
+}
+
+# AC1 — Edit to a non-pipeline file is always allowed
+@test "[AC1] Edit to hooks/lib/foo.sh not blocked by pipeline ordering → exit 0" {
+  setup_full_draft
+
+  run "$HOOK" <<< '{"tool_name":"Edit","tool_input":{"file_path":"/some/project/hooks/lib/foo.sh","old_string":"a","new_string":"b"}}'
+  [ "$status" -eq 0 ]
+}
+
+# ── Criterion 1: Block output format ─────────────────────────────────────────
+
+# AC1 — Blocked response is valid JSON with decision="block"
+@test "[AC1] Blocked write produces valid JSON with decision=block" {
+  create_artifact "$ARTIFACT_DIR/goals.md"            "draft"
+  create_artifact "$ARTIFACT_DIR/questions.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact "$ARTIFACT_DIR/design.md"           "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md"             "draft"
+  init_state "$ARTIFACT_DIR"
+
+  run "$HOOK" <<< "$(write_json "$ARTIFACT_DIR/design.md")"
+  [ "$status" -eq 2 ]
+  # Last line of output is the JSON response (first line is stderr diagnostic)
+  local json_line="${lines[-1]}"
+  echo "$json_line" | jq . > /dev/null
+  [[ "$(echo "$json_line" | jq -r '.decision')" == "block" ]]
+}
+
+# AC1 — Block reason is a non-empty string
+@test "[AC1] Blocked write reason field is a non-empty string" {
+  create_artifact "$ARTIFACT_DIR/goals.md"            "draft"
+  create_artifact "$ARTIFACT_DIR/questions.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact "$ARTIFACT_DIR/design.md"           "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md"        "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md"             "draft"
+  init_state "$ARTIFACT_DIR"
+
+  run "$HOOK" <<< "$(write_json "$ARTIFACT_DIR/design.md")"
+  [ "$status" -eq 2 ]
+  local json_line="${lines[-1]}"
+  local reason
+  reason=$(echo "$json_line" | jq -r '.reason')
+  [[ -n "$reason" ]]
+}
+
+# ── Criterion 1: Fail-closed for enforcement state, fail-open for stdin ──────
+
+# AC1 — No state file → fail-closed (exit 2) when writing a pipeline artifact
+@test "[AC1] No state file → allows artifact write (no pipeline to enforce yet)" {
+  # WORK_DIR has no .qrspi/state.json — no pipeline state means no ordering
+  # to enforce. State is created by QRSPI skills when they initialize the
+  # artifact directory. Hooks only read state, they don't create it.
+  run "$HOOK" <<< "$(write_json "$ARTIFACT_DIR/design.md")"
+  [ "$status" -eq 0 ]
+}
+
+# AC1 — No state file → non-artifact writes still allowed (no enforcement context needed)
+@test "[AC1][fail-open] No state file → allows non-artifact write" {
+  # WORK_DIR has no .qrspi/state.json — writing a non-artifact file should pass
+  # (pipeline ordering only applies to artifact files)
+  run "$HOOK" <<< '{"tool_name":"Write","tool_input":{"file_path":"/tmp/any-file.sh","content":"x"}}'
+  [ "$status" -eq 0 ]
+}
+
+# AC1 — Malformed JSON on stdin → fail-closed
+@test "[AC1][fail-closed] Malformed JSON on stdin → hook blocks (exit 2)" {
+  run "$HOOK" <<< "not json at all"
+  [ "$status" -eq 2 ]
+}
+
+# AC1 — Bash tool calls always pass ordering check (ordering only applies to Write/Edit)
+@test "[AC1] Bash tool call is not subject to pipeline ordering → exit 0" {
+  setup_full_draft
+
+  run "$HOOK" <<< '{"tool_name":"Bash","tool_input":{"command":"echo hello"}}'
+  [ "$status" -eq 0 ]
+}

--- a/tests/fixtures/approved-goals.md
+++ b/tests/fixtures/approved-goals.md
@@ -1,0 +1,7 @@
+---
+status: approved
+---
+
+# Goals
+
+Goal content here.

--- a/tests/fixtures/approved-plan.md
+++ b/tests/fixtures/approved-plan.md
@@ -1,0 +1,7 @@
+---
+status: approved
+---
+
+# Plan
+
+Plan content.

--- a/tests/fixtures/approved-questions.md
+++ b/tests/fixtures/approved-questions.md
@@ -1,0 +1,7 @@
+---
+status: approved
+---
+
+# Questions
+
+Question content.

--- a/tests/fixtures/approved-research-summary.md
+++ b/tests/fixtures/approved-research-summary.md
@@ -1,0 +1,7 @@
+---
+status: approved
+---
+
+# Research Summary
+
+Research findings.

--- a/tests/fixtures/approved-structure.md
+++ b/tests/fixtures/approved-structure.md
@@ -1,0 +1,7 @@
+---
+status: approved
+---
+
+# Structure
+
+Structure content.

--- a/tests/fixtures/config-full.md
+++ b/tests/fixtures/config-full.md
@@ -1,0 +1,6 @@
+---
+codex_reviews: true
+review_depth: deep
+review_mode: loop
+enforcement_default: monitored
+---

--- a/tests/fixtures/config-missing-phase4.md
+++ b/tests/fixtures/config-missing-phase4.md
@@ -1,0 +1,5 @@
+---
+codex_reviews: true
+review_depth: deep
+review_mode: loop
+---

--- a/tests/fixtures/draft-design.md
+++ b/tests/fixtures/draft-design.md
@@ -1,0 +1,7 @@
+---
+status: draft
+---
+
+# Design
+
+Design content here.

--- a/tests/fixtures/extra-whitespace-status.md
+++ b/tests/fixtures/extra-whitespace-status.md
@@ -1,0 +1,5 @@
+---
+status:  approved 
+---
+
+# Test

--- a/tests/fixtures/malformed-frontmatter.md
+++ b/tests/fixtures/malformed-frontmatter.md
@@ -1,0 +1,6 @@
+---
+status: approved
+task: 1
+phase: 1
+enforcement: strict
+---

--- a/tests/fixtures/no-frontmatter.md
+++ b/tests/fixtures/no-frontmatter.md
@@ -1,0 +1,3 @@
+# No Frontmatter
+
+This file has no YAML frontmatter.

--- a/tests/fixtures/no-status-field.md
+++ b/tests/fixtures/no-status-field.md
@@ -1,0 +1,6 @@
+---
+task: 1
+phase: 1
+---
+
+# No Status

--- a/tests/fixtures/status-after-line5.md
+++ b/tests/fixtures/status-after-line5.md
@@ -1,0 +1,6 @@
+---
+task: 1
+---
+
+Some body text.
+status: approved

--- a/tests/fixtures/task-spec-full.md
+++ b/tests/fixtures/task-spec-full.md
@@ -1,0 +1,18 @@
+---
+status: approved
+task: 5
+phase: 1
+enforcement: strict
+allowed_files:
+  - action: create
+    path: hooks/lib/example.sh
+  - action: modify
+    path: hooks/session-start
+constraints:
+  - Must source frontmatter.sh
+  - No external dependencies
+---
+
+# Task 5: Example
+
+Task description here.

--- a/tests/fixtures/task-spec-missing-enforcement.md
+++ b/tests/fixtures/task-spec-missing-enforcement.md
@@ -1,0 +1,9 @@
+---
+status: approved
+task: 3
+phase: 1
+---
+
+# Task 3: Legacy
+
+Task without enforcement metadata.

--- a/tests/unit/test-artifact.bats
+++ b/tests/unit/test-artifact.bats
@@ -1,0 +1,371 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+setup() {
+  # Create temp directories
+  export ARTIFACT_DIR=$(mktemp -d)
+  export WORK_DIR=$(mktemp -d)
+  cd "$WORK_DIR"
+
+  # Source the artifact library (which sources pipeline.sh)
+  source "$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/artifact.sh"
+}
+
+teardown() {
+  rm -rf "$ARTIFACT_DIR" "$WORK_DIR"
+}
+
+# Helper function to create a markdown file with frontmatter
+create_artifact_file() {
+  local file="$1"
+  local status="$2"
+  local wireframe_requested="${3:-}"
+  local dir="$(dirname "$file")"
+
+  mkdir -p "$dir"
+
+  if [[ -z "$wireframe_requested" ]]; then
+    cat > "$file" <<EOF
+---
+status: $status
+---
+EOF
+  else
+    cat > "$file" <<EOF
+---
+status: $status
+wireframe_requested: $wireframe_requested
+---
+EOF
+  fi
+}
+
+# Test 1: ARTIFACT_FILES has exactly 6 entries
+@test "ARTIFACT_FILES has exactly 6 entries" {
+  # Check in the library file
+  local lib_file
+  lib_file="$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/artifact.sh"
+
+  # Verify the array contains all 6 paths
+  local content
+  content=$(sed -n '/^declare -a ARTIFACT_FILES=/,/^)/p' "$lib_file")
+  [[ "$content" == *"goals.md"* ]]
+  [[ "$content" == *"questions.md"* ]]
+  [[ "$content" == *"research/summary.md"* ]]
+  [[ "$content" == *"design.md"* ]]
+  [[ "$content" == *"structure.md"* ]]
+  [[ "$content" == *"plan.md"* ]]
+
+  # Count lines with .md entries to verify exactly 6
+  local line_count
+  line_count=$(echo "$content" | grep -c '\.md' || echo 0)
+  [[ "$line_count" -eq 6 ]]
+}
+
+# Test 2: Library uses set -euo pipefail
+@test "Library uses set -euo pipefail" {
+  local lib_file
+  lib_file="$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/artifact.sh"
+
+  [[ $(head -2 "$lib_file") == *"set -euo pipefail"* ]]
+}
+
+# Test 3: Library sources pipeline.sh
+@test "Library sources pipeline.sh" {
+  local lib_file
+  lib_file="$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/artifact.sh"
+
+  [[ $(cat "$lib_file") == *"source"*"pipeline.sh"* ]]
+}
+
+# Test 4: artifact_is_known with goals.md returns 0 and outputs "goals"
+@test "artifact_is_known goals.md returns 0 and outputs 'goals'" {
+  create_artifact_file "$ARTIFACT_DIR/goals.md" "draft"
+
+  run artifact_is_known "$ARTIFACT_DIR/goals.md" "$ARTIFACT_DIR"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "goals" ]
+}
+
+# Test 5: artifact_is_known with research/summary.md returns 0 and outputs "research"
+@test "artifact_is_known research/summary.md returns 0 and outputs 'research'" {
+  mkdir -p "$ARTIFACT_DIR/research"
+  create_artifact_file "$ARTIFACT_DIR/research/summary.md" "draft"
+
+  run artifact_is_known "$ARTIFACT_DIR/research/summary.md" "$ARTIFACT_DIR"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "research" ]
+}
+
+# Test 6: artifact_is_known with design.md returns 0 and outputs "design"
+@test "artifact_is_known design.md returns 0 and outputs 'design'" {
+  create_artifact_file "$ARTIFACT_DIR/design.md" "draft"
+
+  run artifact_is_known "$ARTIFACT_DIR/design.md" "$ARTIFACT_DIR"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "design" ]
+}
+
+# Test 7: artifact_is_known with questions.md returns 0 and outputs "questions"
+@test "artifact_is_known questions.md returns 0 and outputs 'questions'" {
+  create_artifact_file "$ARTIFACT_DIR/questions.md" "draft"
+
+  run artifact_is_known "$ARTIFACT_DIR/questions.md" "$ARTIFACT_DIR"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "questions" ]
+}
+
+# Test 8: artifact_is_known with structure.md returns 0 and outputs "structure"
+@test "artifact_is_known structure.md returns 0 and outputs 'structure'" {
+  create_artifact_file "$ARTIFACT_DIR/structure.md" "draft"
+
+  run artifact_is_known "$ARTIFACT_DIR/structure.md" "$ARTIFACT_DIR"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "structure" ]
+}
+
+# Test 9: artifact_is_known with plan.md returns 0 and outputs "plan"
+@test "artifact_is_known plan.md returns 0 and outputs 'plan'" {
+  create_artifact_file "$ARTIFACT_DIR/plan.md" "draft"
+
+  run artifact_is_known "$ARTIFACT_DIR/plan.md" "$ARTIFACT_DIR"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "plan" ]
+}
+
+# Test 10: artifact_is_known with hooks/lib/task.sh returns 1
+@test "artifact_is_known hooks/lib/task.sh returns 1" {
+  mkdir -p "$WORK_DIR/hooks/lib"
+  echo "# dummy" > "$WORK_DIR/hooks/lib/task.sh"
+
+  run artifact_is_known "$WORK_DIR/hooks/lib/task.sh" "$ARTIFACT_DIR"
+
+  [ "$status" -eq 1 ]
+}
+
+# Test 11: artifact_is_known with some-other-goals.md outside artifact dir returns 1
+@test "artifact_is_known some-other-goals.md outside artifact dir returns 1" {
+  mkdir -p "$WORK_DIR/other"
+  echo "# dummy" > "$WORK_DIR/other/some-other-goals.md"
+
+  run artifact_is_known "$WORK_DIR/other/some-other-goals.md" "$ARTIFACT_DIR"
+
+  [ "$status" -eq 1 ]
+}
+
+# Test 12: artifact_is_known with absolute path works
+@test "artifact_is_known with absolute path works" {
+  create_artifact_file "$ARTIFACT_DIR/goals.md" "draft"
+  local abs_path
+  abs_path="$(cd "$ARTIFACT_DIR" && pwd)/goals.md"
+
+  run artifact_is_known "$abs_path" "$ARTIFACT_DIR"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "goals" ]
+}
+
+# Test 13: artifact_sync_state on approved artifact updates state to approved
+@test "artifact_sync_state on approved artifact updates state to approved" {
+  create_artifact_file "$ARTIFACT_DIR/goals.md" "draft"
+  mkdir -p "$ARTIFACT_DIR/research"
+  create_artifact_file "$ARTIFACT_DIR/questions.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/design.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/plan.md" "draft"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Update goals.md to approved
+  create_artifact_file "$ARTIFACT_DIR/goals.md" "approved"
+
+  # Sync state
+  artifact_sync_state "$ARTIFACT_DIR/goals.md" "$ARTIFACT_DIR"
+
+  # Verify state was updated using jq
+  local state
+  state=$(state_read)
+  [[ $(echo "$state" | jq -r '.artifacts.goals') == "approved" ]]
+}
+
+# Test 14: artifact_sync_state on draft artifact triggers cascade reset
+@test "artifact_sync_state on draft artifact triggers cascade reset" {
+  create_artifact_file "$ARTIFACT_DIR/goals.md" "approved"
+  mkdir -p "$ARTIFACT_DIR/research"
+  create_artifact_file "$ARTIFACT_DIR/questions.md" "approved"
+  create_artifact_file "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/design.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/plan.md" "draft"
+
+  # Initialize state with some approved
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Verify initial state
+  local state
+  state=$(state_read)
+  [[ $(echo "$state" | jq -r '.artifacts.questions') == "approved" ]]
+
+  # Update questions to draft
+  create_artifact_file "$ARTIFACT_DIR/questions.md" "draft"
+
+  # Sync state
+  artifact_sync_state "$ARTIFACT_DIR/questions.md" "$ARTIFACT_DIR"
+
+  # Verify cascade reset occurred using jq
+  state=$(state_read)
+  [[ $(echo "$state" | jq -r '.artifacts.questions') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.research') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.design') == "draft" ]]
+}
+
+# Test 15: artifact_sync_state cascade: resetting design resets structure and plan
+@test "artifact_sync_state cascade: design reset resets structure and plan" {
+  create_artifact_file "$ARTIFACT_DIR/goals.md" "approved"
+  mkdir -p "$ARTIFACT_DIR/research"
+  create_artifact_file "$ARTIFACT_DIR/questions.md" "approved"
+  create_artifact_file "$ARTIFACT_DIR/research/summary.md" "approved"
+  create_artifact_file "$ARTIFACT_DIR/design.md" "approved"
+  create_artifact_file "$ARTIFACT_DIR/structure.md" "approved"
+  create_artifact_file "$ARTIFACT_DIR/plan.md" "approved"
+
+  # Initialize state with all approved
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Update design to draft
+  create_artifact_file "$ARTIFACT_DIR/design.md" "draft"
+
+  # Sync state
+  artifact_sync_state "$ARTIFACT_DIR/design.md" "$ARTIFACT_DIR"
+
+  # Verify cascade reset using jq
+  local state
+  state=$(state_read)
+  [[ $(echo "$state" | jq -r '.artifacts.design') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.structure') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.plan') == "draft" ]]
+  # But goals, questions, research should remain approved
+  [[ $(echo "$state" | jq -r '.artifacts.goals') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.questions') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.research') == "approved" ]]
+}
+
+# Test 16: artifact_sync_state on design.md with wireframe_requested:true syncs to state
+@test "artifact_sync_state design.md with wireframe_requested:true syncs to state" {
+  create_artifact_file "$ARTIFACT_DIR/goals.md" "draft"
+  mkdir -p "$ARTIFACT_DIR/research"
+  create_artifact_file "$ARTIFACT_DIR/questions.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/design.md" "draft" "true"
+  create_artifact_file "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/plan.md" "draft"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Sync state with design.md
+  artifact_sync_state "$ARTIFACT_DIR/design.md" "$ARTIFACT_DIR"
+
+  # Verify wireframe_requested was synced using jq
+  local state
+  state=$(state_read)
+  [[ $(echo "$state" | jq -r '.wireframe_requested') == "true" ]]
+}
+
+# Test 17: artifact_sync_state on design.md with wireframe_requested:false syncs to state
+@test "artifact_sync_state design.md with wireframe_requested:false syncs to state" {
+  create_artifact_file "$ARTIFACT_DIR/goals.md" "draft"
+  mkdir -p "$ARTIFACT_DIR/research"
+  create_artifact_file "$ARTIFACT_DIR/questions.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/design.md" "draft" "false"
+  create_artifact_file "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/plan.md" "draft"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Sync state with design.md
+  artifact_sync_state "$ARTIFACT_DIR/design.md" "$ARTIFACT_DIR"
+
+  # Verify wireframe_requested was synced using jq
+  local state
+  state=$(state_read)
+  [[ $(echo "$state" | jq -r '.wireframe_requested') == "false" ]]
+}
+
+# Test 18: artifact_sync_state on design.md without wireframe_requested doesn't error
+@test "artifact_sync_state design.md without wireframe_requested doesn't error" {
+  create_artifact_file "$ARTIFACT_DIR/goals.md" "draft"
+  mkdir -p "$ARTIFACT_DIR/research"
+  create_artifact_file "$ARTIFACT_DIR/questions.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/design.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/plan.md" "draft"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Sync state with design.md (no wireframe_requested field)
+  run artifact_sync_state "$ARTIFACT_DIR/design.md" "$ARTIFACT_DIR"
+
+  [ "$status" -eq 0 ]
+}
+
+# Test 19: artifact_sync_state on non-design.md doesn't attempt wireframe sync
+@test "artifact_sync_state goals.md doesn't sync wireframe_requested" {
+  create_artifact_file "$ARTIFACT_DIR/goals.md" "draft" "true"
+  mkdir -p "$ARTIFACT_DIR/research"
+  create_artifact_file "$ARTIFACT_DIR/questions.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/design.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/plan.md" "draft"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Sync state with goals.md
+  artifact_sync_state "$ARTIFACT_DIR/goals.md" "$ARTIFACT_DIR"
+
+  # Verify wireframe_requested is still false using jq (not synced from goals)
+  local state
+  state=$(state_read)
+  [[ $(echo "$state" | jq -r '.wireframe_requested') == "false" ]]
+}
+
+# Test 20: State written atomically (file exists after write)
+@test "artifact_sync_state writes state atomically" {
+  create_artifact_file "$ARTIFACT_DIR/goals.md" "approved"
+  mkdir -p "$ARTIFACT_DIR/research"
+  create_artifact_file "$ARTIFACT_DIR/questions.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/design.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact_file "$ARTIFACT_DIR/plan.md" "draft"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Sync state
+  artifact_sync_state "$ARTIFACT_DIR/goals.md" "$ARTIFACT_DIR"
+
+  # Verify state file exists and is valid JSON
+  [[ -f ".qrspi/state.json" ]]
+
+  local state
+  state=$(state_read)
+  [[ -n "$state" ]]
+
+  # Verify it's valid JSON
+  echo "$state" | jq . >/dev/null 2>&1
+}

--- a/tests/unit/test-audit.bats
+++ b/tests/unit/test-audit.bats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bats
+
+setup() {
+  # Create temp directory for test audit files
+  export TEST_DIR="$(mktemp -d)"
+  cd "$TEST_DIR"
+
+  # Source the audit library
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/audit.sh"
+}
+
+teardown() {
+  # Clean up temp directory
+  rm -rf "$TEST_DIR"
+}
+
+# Test 1: Creates JSONL file if doesn't exist
+@test "audit_log_operation creates JSONL file if doesn't exist" {
+  run audit_log_operation "3" "2026-04-07T10:30:00Z" "Write" "/path/to/file.txt" '[]' "null" "true" "monitored" "false" "null"
+  [ "$status" -eq 0 ]
+  [ -f ".qrspi/audit-task-03.jsonl" ]
+}
+
+# Test 2: Appends to existing file without overwriting
+@test "audit_log_operation appends to existing file without overwriting" {
+  audit_log_operation "5" "2026-04-07T10:00:00Z" "Write" "/file1.txt" '[]' "null" "true" "monitored" "false" "null"
+  audit_log_operation "5" "2026-04-07T10:01:00Z" "Edit" "/file2.txt" '[]' "null" "false" "strict" "true" "null"
+
+  [ -f ".qrspi/audit-task-05.jsonl" ]
+  line_count=$(wc -l < ".qrspi/audit-task-05.jsonl")
+  [ "$line_count" -eq 2 ]
+}
+
+# Test 3: Each line is valid JSON (parseable by jq)
+@test "audit_log_operation produces valid JSON lines" {
+  audit_log_operation "7" "2026-04-07T10:00:00Z" "Write" "/file.txt" '[]' "null" "true" "monitored" "false" "null"
+
+  run jq '.' ".qrspi/audit-task-07.jsonl"
+  [ "$status" -eq 0 ]
+}
+
+# Test 4: Record has all required fields
+@test "audit_log_operation record has all required fields" {
+  audit_log_operation "8" "2026-04-07T10:00:00Z" "Write" "/file.txt" '["file1.txt"]' "null" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-08.jsonl")
+  echo "$record" | jq 'has("timestamp") and has("tool") and has("target") and has("targets") and has("command") and has("in_scope") and has("enforcement") and has("user_approved") and has("destructive_flag")'
+  [ "$(echo "$record" | jq 'has("timestamp") and has("tool") and has("target") and has("targets") and has("command") and has("in_scope") and has("enforcement") and has("user_approved") and has("destructive_flag")')" = "true" ]
+}
+
+# Test 5: timestamp is ISO 8601
+@test "audit_log_operation timestamp is ISO 8601" {
+  audit_log_operation "9" "2026-04-07T15:45:30Z" "Write" "/file.txt" '[]' "null" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-09.jsonl")
+  local ts=$(echo "$record" | jq -r '.timestamp')
+  [ "$ts" = "2026-04-07T15:45:30Z" ]
+}
+
+# Test 6: tool matches argument
+@test "audit_log_operation tool matches argument" {
+  audit_log_operation "10" "2026-04-07T10:00:00Z" "Bash" "/file.txt" '[]' "ls -la" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-10.jsonl")
+  [ "$(echo "$record" | jq -r '.tool')" = "Bash" ]
+}
+
+# Test 7: command is null for Write
+@test "audit_log_operation command is null for Write" {
+  audit_log_operation "11" "2026-04-07T10:00:00Z" "Write" "/file.txt" '[]' "null" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-11.jsonl")
+  [ "$(echo "$record" | jq '.command')" = "null" ]
+}
+
+# Test 8: command is null for Edit
+@test "audit_log_operation command is null for Edit" {
+  audit_log_operation "12" "2026-04-07T10:00:00Z" "Edit" "/file.txt" '[]' "null" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-12.jsonl")
+  [ "$(echo "$record" | jq '.command')" = "null" ]
+}
+
+# Test 9: command contains string for Bash
+@test "audit_log_operation command contains string for Bash" {
+  audit_log_operation "13" "2026-04-07T10:00:00Z" "Bash" "/file.txt" '[]' "rm -rf /tmp/test" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-13.jsonl")
+  [ "$(echo "$record" | jq -r '.command')" = "rm -rf /tmp/test" ]
+}
+
+# Test 10: targets is a JSON array
+@test "audit_log_operation targets is a JSON array" {
+  audit_log_operation "14" "2026-04-07T10:00:00Z" "Write" "/file.txt" '["file1.txt", "file2.txt"]' "null" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-14.jsonl")
+  local targets=$(echo "$record" | jq '.targets')
+  [ "$(echo "$targets" | jq 'type')" = '"array"' ]
+}
+
+# Test 11: in_scope is boolean (not string)
+@test "audit_log_operation in_scope is boolean true" {
+  audit_log_operation "15" "2026-04-07T10:00:00Z" "Write" "/file.txt" '[]' "null" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-15.jsonl")
+  [ "$(echo "$record" | jq '.in_scope')" = "true" ]
+  [ "$(echo "$record" | jq '.in_scope | type')" = '"boolean"' ]
+}
+
+# Test 12: in_scope is boolean false
+@test "audit_log_operation in_scope is boolean false" {
+  audit_log_operation "16" "2026-04-07T10:00:00Z" "Write" "/file.txt" '[]' "null" "false" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-16.jsonl")
+  [ "$(echo "$record" | jq '.in_scope')" = "false" ]
+  [ "$(echo "$record" | jq '.in_scope | type')" = '"boolean"' ]
+}
+
+# Test 13: user_approved is boolean
+@test "audit_log_operation user_approved is boolean" {
+  audit_log_operation "17" "2026-04-07T10:00:00Z" "Write" "/file.txt" '[]' "null" "true" "monitored" "true" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-17.jsonl")
+  [ "$(echo "$record" | jq '.user_approved')" = "true" ]
+  [ "$(echo "$record" | jq '.user_approved | type')" = '"boolean"' ]
+}
+
+# Test 14: destructive_flag is null when "null" passed
+@test "audit_log_operation destructive_flag is null when null passed" {
+  audit_log_operation "18" "2026-04-07T10:00:00Z" "Bash" "/file.txt" '[]' "rm file.txt" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-18.jsonl")
+  [ "$(echo "$record" | jq '.destructive_flag')" = "null" ]
+}
+
+# Test 15: destructive_flag has value when pattern name passed
+@test "audit_log_operation destructive_flag has value when pattern passed" {
+  audit_log_operation "19" "2026-04-07T10:00:00Z" "Bash" "/file.txt" '[]' "rm -rf /" "true" "monitored" "false" "destructive_rm_rf"
+
+  local record=$(head -1 ".qrspi/audit-task-19.jsonl")
+  [ "$(echo "$record" | jq -r '.destructive_flag')" = "destructive_rm_rf" ]
+}
+
+# Test 16: Multiple calls produce multiple lines
+@test "audit_log_operation multiple calls produce multiple lines" {
+  audit_log_operation "20" "2026-04-07T10:00:00Z" "Write" "/file1.txt" '[]' "null" "true" "monitored" "false" "null"
+  audit_log_operation "20" "2026-04-07T10:01:00Z" "Edit" "/file2.txt" '[]' "null" "true" "monitored" "false" "null"
+  audit_log_operation "20" "2026-04-07T10:02:00Z" "Bash" "/file3.txt" '[]' "ls" "false" "strict" "true" "null"
+
+  line_count=$(wc -l < ".qrspi/audit-task-20.jsonl")
+  [ "$line_count" -eq 3 ]
+}
+
+# Test 17: Correct file path for task ID 3
+@test "audit_log_operation correct file path for task-03" {
+  audit_log_operation "3" "2026-04-07T10:00:00Z" "Write" "/file.txt" '[]' "null" "true" "monitored" "false" "null"
+  [ -f ".qrspi/audit-task-03.jsonl" ]
+}
+
+# Test 18: Correct file path for task ID 15
+@test "audit_log_operation correct file path for task-15" {
+  audit_log_operation "15" "2026-04-07T10:00:00Z" "Write" "/file.txt" '[]' "null" "true" "monitored" "false" "null"
+  [ -f ".qrspi/audit-task-15.jsonl" ]
+}
+
+# Test 19: enforcement field is preserved
+@test "audit_log_operation enforcement field matches argument" {
+  audit_log_operation "21" "2026-04-07T10:00:00Z" "Write" "/file.txt" '[]' "null" "true" "strict" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-21.jsonl")
+  [ "$(echo "$record" | jq -r '.enforcement')" = "strict" ]
+}
+
+# Test 20: target field contains primary file path
+@test "audit_log_operation target field contains primary file path" {
+  audit_log_operation "22" "2026-04-07T10:00:00Z" "Write" "/primary/path.txt" '[]' "null" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-22.jsonl")
+  [ "$(echo "$record" | jq -r '.target')" = "/primary/path.txt" ]
+}
+
+# Test 21: command with special characters (quotes, backslashes, newlines) is properly escaped
+@test "audit_log_operation command with special characters is properly escaped" {
+  local cmd='echo "hello\nworld" && grep "test" file.txt'
+  audit_log_operation "23" "2026-04-07T10:00:00Z" "Bash" "/file.txt" '[]' "$cmd" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-23.jsonl")
+  local cmd_field=$(echo "$record" | jq -r '.command')
+  [ "$cmd_field" = "$cmd" ]
+}
+
+# Test 22: destructive_flag with special characters is properly escaped
+@test "audit_log_operation destructive_flag with special characters is properly escaped" {
+  local pattern='pattern_with_"quotes"_and\backslashes'
+  audit_log_operation "24" "2026-04-07T10:00:00Z" "Bash" "/file.txt" '[]' "rm file.txt" "true" "monitored" "false" "$pattern"
+
+  local record=$(head -1 ".qrspi/audit-task-24.jsonl")
+  local flag=$(echo "$record" | jq -r '.destructive_flag')
+  [ "$flag" = "$pattern" ]
+}
+
+# Test 23: target path with special characters is properly escaped
+@test "audit_log_operation target path with special characters is properly escaped" {
+  local path='/path/with "quotes" and\backslashes/file.txt'
+  audit_log_operation "25" "2026-04-07T10:00:00Z" "Write" "$path" '[]' "null" "true" "monitored" "false" "null"
+
+  local record=$(head -1 ".qrspi/audit-task-25.jsonl")
+  local target=$(echo "$record" | jq -r '.target')
+  [ "$target" = "$path" ]
+}

--- a/tests/unit/test-bash-detect.bats
+++ b/tests/unit/test-bash-detect.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+
+setup() {
+  source "$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/hooks/lib/bash-detect.sh"
+}
+
+# Helper to check if output contains expected path
+assert_contains_path() {
+    local output="$1"
+    local expected_path="$2"
+    if [[ ! "$output" =~ $expected_path ]]; then
+        echo "Expected path not found: $expected_path"
+        echo "Got output: $output"
+        return 1
+    fi
+}
+
+# Helper to check output is empty
+assert_empty() {
+    local output="$1"
+    if [[ -n "$output" ]]; then
+        echo "Expected empty output, got: $output"
+        return 1
+    fi
+}
+
+# Test 1: Simple redirect >
+@test "detects simple output redirect > /tmp/out.txt" {
+    result=$(bash_detect_file_writes 'echo foo > /tmp/out.txt')
+    assert_contains_path "$result" "/tmp/out.txt"
+}
+
+# Test 2: Append redirect >>
+@test "detects append redirect >> /tmp/out.txt" {
+    result=$(bash_detect_file_writes 'echo foo >> /tmp/out.txt')
+    assert_contains_path "$result" "/tmp/out.txt"
+}
+
+# Test 3: sed -i
+@test "detects sed -i on config.txt" {
+    result=$(bash_detect_file_writes "sed -i 's/foo/bar/' config.txt")
+    assert_contains_path "$result" "config.txt"
+}
+
+# Test 4: sed -i.bak
+@test "detects sed -i.bak on config.txt" {
+    result=$(bash_detect_file_writes "sed -i.bak 's/foo/bar/' config.txt")
+    assert_contains_path "$result" "config.txt"
+}
+
+# Test 5: cp destination
+@test "detects cp destination file" {
+    result=$(bash_detect_file_writes 'cp source.txt dest.txt')
+    assert_contains_path "$result" "dest.txt"
+}
+
+# Test 6: mv destination
+@test "detects mv destination file" {
+    result=$(bash_detect_file_writes 'mv old.txt new.txt')
+    assert_contains_path "$result" "new.txt"
+}
+
+# Test 7: tee
+@test "detects tee output.txt" {
+    result=$(bash_detect_file_writes 'echo foo | tee output.txt')
+    assert_contains_path "$result" "output.txt"
+}
+
+# Test 8: tee -a
+@test "detects tee -a output.txt" {
+    result=$(bash_detect_file_writes 'tee -a output.txt')
+    assert_contains_path "$result" "output.txt"
+}
+
+# Test 9: cat with redirect
+@test "detects cat input.txt > output.txt" {
+    result=$(bash_detect_file_writes 'cat input.txt > output.txt')
+    assert_contains_path "$result" "output.txt"
+}
+
+# Test 10: No file write (ls)
+@test "returns empty for ls -la" {
+    result=$(bash_detect_file_writes 'ls -la')
+    assert_empty "$result"
+}
+
+# Test 11: No file write (grep)
+@test "returns empty for grep pattern file.txt" {
+    result=$(bash_detect_file_writes 'grep pattern file.txt')
+    assert_empty "$result"
+}
+
+# Test 12: No file write (echo without redirect)
+@test "returns empty for echo hello" {
+    result=$(bash_detect_file_writes 'echo hello')
+    assert_empty "$result"
+}
+
+# Test 13: Compound command with && (multiple writes)
+@test "detects multiple writes in compound command a.txt && c.txt" {
+    result=$(bash_detect_file_writes 'cp a.txt b.txt && echo x > c.txt')
+    assert_contains_path "$result" "b.txt"
+    assert_contains_path "$result" "c.txt"
+}
+
+# Test 14: Paths with spaces in quotes
+@test "detects path with spaces in quotes" {
+    result=$(bash_detect_file_writes 'echo foo > "path with spaces/file.txt"')
+    assert_contains_path "$result" "path with spaces/file.txt"
+}
+
+# Test 15: Always returns exit code 0
+@test "function returns exit code 0" {
+    bash_detect_file_writes 'nonexistent_command'
+    [ $? -eq 0 ]
+}
+
+# Test 16: Library uses set -euo pipefail (verify by checking stderr handling)
+@test "library uses set -euo pipefail" {
+    # This test verifies the library source can be loaded without error
+    # and basic operations work
+    result=$(bash_detect_file_writes 'echo test > file.txt')
+    [ -n "$result" ]
+}

--- a/tests/unit/test-enforcement.bats
+++ b/tests/unit/test-enforcement.bats
@@ -1,0 +1,275 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_TEMP_DIR
+  TEST_TEMP_DIR="$(mktemp -d)"
+  export ARTIFACT_DIR="$TEST_TEMP_DIR/artifacts"
+  mkdir -p "$ARTIFACT_DIR/tasks"
+  mkdir -p "$TEST_TEMP_DIR/.qrspi"
+
+  # Source the enforcement library
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/enforcement.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+# Helper: create task spec file
+create_task_spec() {
+  local file_path="$1"
+  local content="$2"
+  mkdir -p "$(dirname "$file_path")"
+  printf "%s" "$content" > "$file_path"
+}
+
+# ============================================================================
+# enforcement_get_mode tests
+# ============================================================================
+
+@test "enforcement_get_mode: returns task spec value when no runtime overrides" {
+  local task_file="$ARTIFACT_DIR/tasks/task-01.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files:
+  - action: create
+    path: hooks/lib/enforcement.sh
+constraints: []
+---
+
+# Task 1
+"
+  cd "$TEST_TEMP_DIR"
+  result=$(enforcement_get_mode 1 "$ARTIFACT_DIR")
+  [[ "$result" == "strict" ]]
+}
+
+@test "enforcement_get_mode: returns monitored from task spec" {
+  local task_file="$ARTIFACT_DIR/tasks/task-02.md"
+  create_task_spec "$task_file" "---
+enforcement: monitored
+allowed_files: []
+constraints: []
+---
+
+# Task 2
+"
+  cd "$TEST_TEMP_DIR"
+  result=$(enforcement_get_mode 2 "$ARTIFACT_DIR")
+  [[ "$result" == "monitored" ]]
+}
+
+@test "enforcement_get_mode: runtime overrides override takes precedence over task spec" {
+  local task_file="$ARTIFACT_DIR/tasks/task-03.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files: []
+constraints: []
+---
+
+# Task 3
+"
+  cd "$TEST_TEMP_DIR"
+  mkdir -p .qrspi
+  printf '{"enforcement":"monitored","user_approved_files":[]}' > ".qrspi/task-03-runtime.json"
+
+  result=$(enforcement_get_mode 3 "$ARTIFACT_DIR")
+  [[ "$result" == "monitored" ]]
+}
+
+@test "enforcement_get_mode: no Phase 4 fields defaults to strict (fail-closed)" {
+  local task_file="$ARTIFACT_DIR/tasks/task-04.md"
+  create_task_spec "$task_file" "---
+title: Old-style task
+---
+
+# Task 4
+"
+  cd "$TEST_TEMP_DIR"
+  result=$(enforcement_get_mode 4 "$ARTIFACT_DIR")
+  [[ "$result" == "strict" ]]
+}
+
+# ============================================================================
+# enforcement_check_allowlist tests
+# ============================================================================
+
+@test "enforcement_check_allowlist: file in allowed_files returns 0 in strict mode" {
+  local task_file="$ARTIFACT_DIR/tasks/task-05.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files:
+  - action: create
+    path: hooks/lib/enforcement.sh
+constraints: []
+---
+
+# Task 5
+"
+  cd "$TEST_TEMP_DIR"
+  run enforcement_check_allowlist "hooks/lib/enforcement.sh" 5 "$ARTIFACT_DIR"
+  [[ $status -eq 0 ]]
+}
+
+@test "enforcement_check_allowlist: file NOT in allowed_files returns 2 in strict mode" {
+  local task_file="$ARTIFACT_DIR/tasks/task-06.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files:
+  - action: create
+    path: hooks/lib/enforcement.sh
+constraints: []
+---
+
+# Task 6
+"
+  cd "$TEST_TEMP_DIR"
+  run enforcement_check_allowlist "some/other/file.sh" 6 "$ARTIFACT_DIR"
+  [[ $status -eq 2 ]]
+}
+
+@test "enforcement_check_allowlist: file in runtime overrides user_approved_files returns 0 in strict mode" {
+  local task_file="$ARTIFACT_DIR/tasks/task-07.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files:
+  - action: create
+    path: hooks/lib/enforcement.sh
+constraints: []
+---
+
+# Task 7
+"
+  cd "$TEST_TEMP_DIR"
+  mkdir -p .qrspi
+  printf '{"enforcement":"strict","user_approved_files":["extra/file.sh"]}' > ".qrspi/task-07-runtime.json"
+
+  run enforcement_check_allowlist "extra/file.sh" 7 "$ARTIFACT_DIR"
+  [[ $status -eq 0 ]]
+}
+
+@test "enforcement_check_allowlist: any file in monitored mode returns 0" {
+  local task_file="$ARTIFACT_DIR/tasks/task-08.md"
+  create_task_spec "$task_file" "---
+enforcement: monitored
+allowed_files: []
+constraints: []
+---
+
+# Task 8
+"
+  cd "$TEST_TEMP_DIR"
+  run enforcement_check_allowlist "any/random/file.sh" 8 "$ARTIFACT_DIR"
+  [[ $status -eq 0 ]]
+}
+
+@test "enforcement_check_allowlist: pre-Phase-4 task defaults to strict (fail-closed), blocks" {
+  local task_file="$ARTIFACT_DIR/tasks/task-09.md"
+  create_task_spec "$task_file" "---
+title: Old-style task
+---
+
+# Task 9
+"
+  cd "$TEST_TEMP_DIR"
+  run enforcement_check_allowlist "any/file.sh" 9 "$ARTIFACT_DIR"
+  [[ $status -eq 2 ]]
+}
+
+@test "enforcement_check_allowlist: strict block writes message with approve, switch, reject to stderr" {
+  local task_file="$ARTIFACT_DIR/tasks/task-10.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files:
+  - action: create
+    path: hooks/lib/enforcement.sh
+constraints: []
+---
+
+# Task 10
+"
+  cd "$TEST_TEMP_DIR"
+  local stderr_file="$TEST_TEMP_DIR/stderr.txt"
+
+  enforcement_check_allowlist "blocked/file.sh" 10 "$ARTIFACT_DIR" 2>"$stderr_file" || true
+
+  stderr_content=$(cat "$stderr_file")
+  [[ "$stderr_content" == *"approve"* ]]
+  [[ "$stderr_content" == *"switch"* ]]
+  [[ "$stderr_content" == *"reject"* ]]
+}
+
+@test "enforcement_check_allowlist: strict block message mentions file path" {
+  local task_file="$ARTIFACT_DIR/tasks/task-11.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files:
+  - action: create
+    path: hooks/lib/enforcement.sh
+constraints: []
+---
+
+# Task 11
+"
+  cd "$TEST_TEMP_DIR"
+  local stderr_file="$TEST_TEMP_DIR/stderr.txt"
+
+  enforcement_check_allowlist "blocked/my-file.sh" 11 "$ARTIFACT_DIR" 2>"$stderr_file" || true
+
+  stderr_content=$(cat "$stderr_file")
+  [[ "$stderr_content" == *"blocked/my-file.sh"* ]]
+}
+
+@test "enforcement_check_allowlist: allowlist handles both create and modify actions" {
+  local task_file="$ARTIFACT_DIR/tasks/task-12.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files:
+  - action: create
+    path: new-file.sh
+  - action: modify
+    path: existing-file.sh
+constraints: []
+---
+
+# Task 12
+"
+  cd "$TEST_TEMP_DIR"
+  run enforcement_check_allowlist "new-file.sh" 12 "$ARTIFACT_DIR"
+  [[ $status -eq 0 ]]
+
+  run enforcement_check_allowlist "existing-file.sh" 12 "$ARTIFACT_DIR"
+  [[ $status -eq 0 ]]
+}
+
+@test "enforcement_check_allowlist: absolute path matched against relative path in allowlist" {
+  local task_file="$ARTIFACT_DIR/tasks/task-13.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files:
+  - action: create
+    path: hooks/lib/enforcement.sh
+constraints: []
+---
+
+# Task 13
+"
+  cd "$TEST_TEMP_DIR"
+  # Pass an absolute path — should strip working dir prefix and match the relative path
+  run enforcement_check_allowlist "$TEST_TEMP_DIR/hooks/lib/enforcement.sh" 13 "$ARTIFACT_DIR"
+  [[ $status -eq 0 ]]
+}
+
+# ============================================================================
+# Library quality tests
+# ============================================================================
+
+@test "enforcement.sh uses set -euo pipefail" {
+  # Verify the script exists and has pipefail enabled (presence of the header)
+  grep -q "set -euo pipefail" "$BATS_TEST_DIRNAME/../../hooks/lib/enforcement.sh"
+}
+
+@test "enforcement.sh sources task.sh" {
+  # Verify task_read_frontmatter is available after sourcing enforcement.sh
+  declare -f task_read_frontmatter > /dev/null
+}

--- a/tests/unit/test-frontmatter.bats
+++ b/tests/unit/test-frontmatter.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  export TEST_DIR
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+@test "frontmatter_get_status: status: approved returns 'approved'" {
+  cat > "$TEST_DIR/file1.md" <<'EOF'
+---
+status: approved
+---
+EOF
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh"
+  run frontmatter_get_status "$TEST_DIR/file1.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "approved" ]
+}
+
+@test "frontmatter_get_status: status: draft returns 'draft'" {
+  cat > "$TEST_DIR/file2.md" <<'EOF'
+---
+status: draft
+---
+EOF
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh"
+  run frontmatter_get_status "$TEST_DIR/file2.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "draft" ]
+}
+
+@test "frontmatter_get_status: no frontmatter (no leading ---) returns 1 with no stdout" {
+  cat > "$TEST_DIR/file3.md" <<'EOF'
+# Title
+Some content
+EOF
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh"
+  run frontmatter_get_status "$TEST_DIR/file3.md"
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+}
+
+@test "frontmatter_get_status: file does not exist returns 1 with no stdout" {
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh"
+  run frontmatter_get_status "$TEST_DIR/nonexistent.md"
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+}
+
+@test "frontmatter_get_status: empty file returns 1 with no stdout" {
+  touch "$TEST_DIR/empty.md"
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh"
+  run frontmatter_get_status "$TEST_DIR/empty.md"
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+}
+
+@test "frontmatter_get_status: malformed frontmatter (opening --- but no closing ---) returns 1" {
+  cat > "$TEST_DIR/malformed.md" <<'EOF'
+---
+status: approved
+some content without closing delimiter
+EOF
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh"
+  run frontmatter_get_status "$TEST_DIR/malformed.md"
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+}
+
+@test "frontmatter_get_status: frontmatter but no status: field returns 1" {
+  cat > "$TEST_DIR/no_status.md" <<'EOF'
+---
+title: My Title
+author: John
+---
+EOF
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh"
+  run frontmatter_get_status "$TEST_DIR/no_status.md"
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+}
+
+@test "frontmatter_get_status: status: field after line 5 returns 1 (only reads first 5 lines)" {
+  cat > "$TEST_DIR/status_late.md" <<'EOF'
+---
+title: Title
+author: Author
+description: Some long description
+other_field: value
+status: approved
+---
+EOF
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh"
+  run frontmatter_get_status "$TEST_DIR/status_late.md"
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+}
+
+@test "frontmatter_get_status: extra whitespace 'status:  approved ' outputs trimmed 'approved'" {
+  cat > "$TEST_DIR/whitespace.md" <<'EOF'
+---
+status:  approved
+---
+EOF
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh"
+  run frontmatter_get_status "$TEST_DIR/whitespace.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "approved" ]
+}
+
+@test "frontmatter_get_status: mixed case 'status: Approved' outputs 'Approved' as-is" {
+  cat > "$TEST_DIR/mixedcase.md" <<'EOF'
+---
+status: Approved
+---
+EOF
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh"
+  run frontmatter_get_status "$TEST_DIR/mixedcase.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Approved" ]
+}
+
+@test "frontmatter.sh starts with #!/usr/bin/env bash" {
+  head -1 "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh" | grep -q '^#!/usr/bin/env bash'
+}
+
+@test "frontmatter.sh has 'set -euo pipefail' as early line" {
+  head -2 "$BATS_TEST_DIRNAME/../../hooks/lib/frontmatter.sh" | tail -1 | grep -q '^set -euo pipefail'
+}

--- a/tests/unit/test-pipeline.bats
+++ b/tests/unit/test-pipeline.bats
@@ -1,0 +1,343 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Setup: create temp artifact dir, temp working dir, and source the library
+setup() {
+  # Create temp directories
+  export ARTIFACT_DIR=$(mktemp -d)
+  export WORK_DIR=$(mktemp -d)
+  cd "$WORK_DIR"
+
+  # Source the pipeline library (which sources state.sh)
+  source "$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/pipeline.sh"
+}
+
+# Cleanup: remove temp directories
+teardown() {
+  rm -rf "$ARTIFACT_DIR" "$WORK_DIR"
+}
+
+# Test 1: PIPELINE_ORDER has exactly 8 elements in correct order
+@test "PIPELINE_ORDER has 8 elements in correct order" {
+  # Get the library file and check it defines PIPELINE_ORDER correctly
+  local lib_file
+  lib_file="$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/pipeline.sh"
+
+  # Extract the declare line and verify it
+  local pipeline_line
+  pipeline_line=$(grep "declare -a PIPELINE_ORDER=" "$lib_file")
+
+  [[ "$pipeline_line" == *"goals"* ]]
+  [[ "$pipeline_line" == *"questions"* ]]
+  [[ "$pipeline_line" == *"research"* ]]
+  [[ "$pipeline_line" == *"design"* ]]
+  [[ "$pipeline_line" == *"structure"* ]]
+  [[ "$pipeline_line" == *"plan"* ]]
+  [[ "$pipeline_line" == *"implement"* ]]
+  [[ "$pipeline_line" == *"test"* ]]
+}
+
+# Test 2: pipeline_check_prerequisites "goals" with all draft returns 0
+@test "pipeline_check_prerequisites goals with all draft returns 0" {
+  # Create artifact files with draft status
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Test
+  pipeline_check_prerequisites "goals" "$ARTIFACT_DIR"
+}
+
+# Test 3: pipeline_check_prerequisites "questions" with goals approved returns 0
+@test "pipeline_check_prerequisites questions with goals approved returns 0" {
+  # Create artifact files
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Test
+  pipeline_check_prerequisites "questions" "$ARTIFACT_DIR"
+}
+
+# Test 4: pipeline_check_prerequisites "questions" with goals draft returns 1 with "goals" on stdout
+@test "pipeline_check_prerequisites questions with goals draft returns 1 and outputs goals" {
+  # Create artifact files with goals as draft
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Test - run and expect failure with "goals" output
+  run -1 pipeline_check_prerequisites "questions" "$ARTIFACT_DIR"
+  [[ "$output" == "goals" ]]
+}
+
+# Test 5: pipeline_check_prerequisites "design" with goals+questions approved, research draft returns 1 with "research"
+@test "pipeline_check_prerequisites design with missing research returns 1 and outputs research" {
+  # Create artifact files
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Test - run and expect failure with "research" output
+  run -1 pipeline_check_prerequisites "design" "$ARTIFACT_DIR"
+  [[ "$output" == "research" ]]
+}
+
+# Test 6: pipeline_check_prerequisites "design" with goals+questions+research approved returns 0
+@test "pipeline_check_prerequisites design with all prerequisites approved returns 0" {
+  # Create artifact files
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Test
+  pipeline_check_prerequisites "design" "$ARTIFACT_DIR"
+}
+
+# Test 7: pipeline_check_prerequisites "implement" with all through plan approved returns 0
+@test "pipeline_check_prerequisites implement with all prerequisites approved returns 0" {
+  # Create artifact files
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Test
+  pipeline_check_prerequisites "implement" "$ARTIFACT_DIR"
+}
+
+# Test 8: pipeline_check_prerequisites "foobar" returns 1
+@test "pipeline_check_prerequisites with invalid step returns 1" {
+  # Create artifact files
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Test
+  pipeline_check_prerequisites "foobar" "$ARTIFACT_DIR" && false || true
+}
+
+# Test 9: pipeline_cascade_reset "design" resets design and downstream to draft
+@test "pipeline_cascade_reset design resets design through test to draft" {
+  # Create artifact files, all approved
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Reset design and downstream
+  pipeline_cascade_reset "design" "$ARTIFACT_DIR"
+
+  # Verify state
+  local state
+  state=$(state_read)
+  [[ $(echo "$state" | jq -r '.artifacts.goals') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.questions') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.research') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.design') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.structure') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.plan') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.implement') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.test') == "draft" ]]
+}
+
+# Test 10: pipeline_cascade_reset "goals" resets all 8 to draft
+@test "pipeline_cascade_reset goals resets all 8 to draft" {
+  # Create artifact files, all approved
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Reset all
+  pipeline_cascade_reset "goals" "$ARTIFACT_DIR"
+
+  # Verify all are draft
+  local state
+  state=$(state_read)
+  [[ $(echo "$state" | jq -r '.artifacts.goals') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.questions') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.research') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.design') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.structure') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.plan') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.implement') == "draft" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.test') == "draft" ]]
+}
+
+# Test 11: pipeline_cascade_reset "test" resets only test to draft
+@test "pipeline_cascade_reset test resets only test to draft" {
+  # Create artifact files, all approved
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Manually mark implement and test as approved (state_init_or_reconcile doesn't do this)
+  local state
+  state=$(state_read)
+  state=$(echo "$state" | jq '.artifacts.implement = "approved"')
+  state=$(echo "$state" | jq '.artifacts.test = "approved"')
+  state_write_atomic "$state"
+
+  # Reset test only
+  pipeline_cascade_reset "test" "$ARTIFACT_DIR"
+
+  # Verify only test is draft
+  state=$(state_read)
+  [[ $(echo "$state" | jq -r '.artifacts.goals') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.questions') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.research') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.design') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.structure') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.plan') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.implement') == "approved" ]]
+  [[ $(echo "$state" | jq -r '.artifacts.test') == "draft" ]]
+}
+
+# Test 12: cascade_reset does NOT modify artifact files on disk
+@test "pipeline_cascade_reset does not modify artifact files on disk" {
+  # Create artifact files
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: approved\n---\nGoals content" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: approved\n---\nQuestions content" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: approved\n---\nResearch content" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: approved\n---\nDesign content" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: approved\n---\nStructure content" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: approved\n---\nPlan content" > "$ARTIFACT_DIR/plan.md"
+
+  # Save original content
+  local goals_original
+  goals_original=$(cat "$ARTIFACT_DIR/goals.md")
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Reset
+  pipeline_cascade_reset "design" "$ARTIFACT_DIR"
+
+  # Verify artifact file unchanged
+  local goals_after
+  goals_after=$(cat "$ARTIFACT_DIR/goals.md")
+  [[ "$goals_original" == "$goals_after" ]]
+}
+
+# Test 13: cascade_reset uses state_write_atomic (verified by checking state file exists and is valid JSON)
+@test "pipeline_cascade_reset uses state_write_atomic to write atomically" {
+  # Create artifact files
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Reset
+  pipeline_cascade_reset "design" "$ARTIFACT_DIR"
+
+  # Verify .qrspi/state.json exists and is valid JSON
+  [[ -f ".qrspi/state.json" ]]
+  state_read | jq . > /dev/null
+}
+
+# Test 14: Dual check - state says approved but frontmatter says draft, trust frontmatter
+@test "pipeline_check_prerequisites dual check trusts frontmatter over state" {
+  # Create artifact files with draft frontmatter
+  mkdir -p "$ARTIFACT_DIR/research"
+  echo -e "---\nstatus: draft\n---" > "$ARTIFACT_DIR/goals.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/questions.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/research/summary.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/design.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/structure.md"
+  echo -e "---\nstatus: approved\n---" > "$ARTIFACT_DIR/plan.md"
+
+  # Initialize state
+  state_init_or_reconcile "$ARTIFACT_DIR"
+
+  # Manually update state to say goals is approved (to test dual check)
+  local state
+  state=$(state_read)
+  state=$(echo "$state" | jq '.artifacts.goals = "approved"')
+  state_write_atomic "$state"
+
+  # Now test: even though state says approved, frontmatter says draft, so should fail
+  run -1 pipeline_check_prerequisites "questions" "$ARTIFACT_DIR"
+  [[ "$output" == "goals" ]]
+}
+
+# Test 15: Library uses set -euo pipefail
+@test "pipeline.sh uses set -euo pipefail" {
+  local lib_content
+  lib_content=$(head -2 "$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/pipeline.sh")
+  [[ "$lib_content" == *"set -euo pipefail"* ]]
+}

--- a/tests/unit/test-pre-tool-use.bats
+++ b/tests/unit/test-pre-tool-use.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Setup: create temp artifact dir and temp working dir with .qrspi/state.json
+setup() {
+  export ARTIFACT_DIR
+  ARTIFACT_DIR=$(mktemp -d)
+  export WORK_DIR
+  WORK_DIR=$(mktemp -d)
+  cd "$WORK_DIR"
+
+  # Create artifact files directory structure
+  mkdir -p "$ARTIFACT_DIR/research"
+
+  # Path to the hook under test
+  export HOOK="$(dirname "$BATS_TEST_FILENAME")/../../hooks/pre-tool-use"
+}
+
+teardown() {
+  rm -rf "$ARTIFACT_DIR" "$WORK_DIR"
+}
+
+# Helper: create an artifact with given status
+create_artifact() {
+  local path="$1"
+  local status="$2"
+  mkdir -p "$(dirname "$path")"
+  printf -- '---\nstatus: %s\n---\nContent\n' "$status" > "$path"
+}
+
+# Helper: init state.json by sourcing pipeline lib and calling state_init_or_reconcile
+init_state() {
+  local artifact_dir="$1"
+  # Source pipeline lib which sources state.sh which sources frontmatter.sh
+  PIPELINE_LIB="$(dirname "$BATS_TEST_FILENAME")/../../hooks/lib/pipeline.sh"
+  bash -c "source '$PIPELINE_LIB'; cd '$WORK_DIR'; state_init_or_reconcile '$artifact_dir'"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 1: Write to design.md with goals+questions+research approved → exit 0
+# ──────────────────────────────────────────────────────────────
+@test "Write to design.md with goals+questions+research approved allows (exit 0)" {
+  create_artifact "$ARTIFACT_DIR/goals.md" "approved"
+  create_artifact "$ARTIFACT_DIR/questions.md" "approved"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "approved"
+  create_artifact "$ARTIFACT_DIR/design.md" "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md" "draft"
+
+  init_state "$ARTIFACT_DIR"
+
+  local json
+  json='{"tool_name":"Write","tool_input":{"file_path":"'"$ARTIFACT_DIR/design.md"'","content":"new content"}}'
+
+  run "$HOOK" <<< "$json"
+  [ "$status" -eq 0 ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 2: Write to design.md with goals draft → exit 2 with "goals" in reason
+# ──────────────────────────────────────────────────────────────
+@test "Write to design.md with goals draft blocks (exit 2) with goals in reason" {
+  create_artifact "$ARTIFACT_DIR/goals.md" "draft"
+  create_artifact "$ARTIFACT_DIR/questions.md" "approved"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "approved"
+  create_artifact "$ARTIFACT_DIR/design.md" "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md" "draft"
+
+  init_state "$ARTIFACT_DIR"
+
+  local json
+  json='{"tool_name":"Write","tool_input":{"file_path":"'"$ARTIFACT_DIR/design.md"'","content":"new content"}}'
+
+  run "$HOOK" <<< "$json"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"goals"* ]]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 3: Edit to structure.md with design not approved → exit 2
+# ──────────────────────────────────────────────────────────────
+@test "Edit to structure.md with design not approved blocks (exit 2)" {
+  create_artifact "$ARTIFACT_DIR/goals.md" "approved"
+  create_artifact "$ARTIFACT_DIR/questions.md" "approved"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "approved"
+  create_artifact "$ARTIFACT_DIR/design.md" "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md" "draft"
+
+  init_state "$ARTIFACT_DIR"
+
+  local json
+  json='{"tool_name":"Edit","tool_input":{"file_path":"'"$ARTIFACT_DIR/structure.md"'","old_string":"old","new_string":"new"}}'
+
+  run "$HOOK" <<< "$json"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"design"* ]]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 4: Write to non-artifact (hooks/lib/foo.sh) → exit 0
+# ──────────────────────────────────────────────────────────────
+@test "Write to non-artifact file allows (exit 0)" {
+  create_artifact "$ARTIFACT_DIR/goals.md" "approved"
+  create_artifact "$ARTIFACT_DIR/questions.md" "approved"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "approved"
+  create_artifact "$ARTIFACT_DIR/design.md" "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md" "draft"
+
+  init_state "$ARTIFACT_DIR"
+
+  local json
+  json='{"tool_name":"Write","tool_input":{"file_path":"/some/project/hooks/lib/foo.sh","content":"#!/bin/bash"}}'
+
+  run "$HOOK" <<< "$json"
+  [ "$status" -eq 0 ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 5: Bash tool call → exit 0
+# ──────────────────────────────────────────────────────────────
+@test "Bash tool call allows (exit 0)" {
+  local json
+  json='{"tool_name":"Bash","tool_input":{"command":"echo hello"}}'
+
+  run "$HOOK" <<< "$json"
+  [ "$status" -eq 0 ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 6: Malformed JSON → exit 2 (fail-closed)
+# ──────────────────────────────────────────────────────────────
+@test "Malformed JSON blocks (exit 2, fail-closed)" {
+  run "$HOOK" <<< "this is not json at all"
+  [ "$status" -eq 2 ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 7: No state file → exit 2 (fail-closed) for artifact writes
+# ──────────────────────────────────────────────────────────────
+@test "No state file allows artifact write (no pipeline to enforce yet)" {
+  # WORK_DIR has no .qrspi/state.json — no pipeline state means no ordering
+  # to enforce. Avoids deadlock where first artifact can never be written.
+
+  local json
+  json='{"tool_name":"Write","tool_input":{"file_path":"'"$ARTIFACT_DIR/design.md"'","content":"content"}}'
+
+  run "$HOOK" <<< "$json"
+  [ "$status" -eq 0 ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 8: stderr message includes next-step instructions on block
+# ──────────────────────────────────────────────────────────────
+@test "Blocked write emits informative stderr message" {
+  create_artifact "$ARTIFACT_DIR/goals.md" "draft"
+  create_artifact "$ARTIFACT_DIR/questions.md" "draft"
+  create_artifact "$ARTIFACT_DIR/research/summary.md" "draft"
+  create_artifact "$ARTIFACT_DIR/design.md" "draft"
+  create_artifact "$ARTIFACT_DIR/structure.md" "draft"
+  create_artifact "$ARTIFACT_DIR/plan.md" "draft"
+
+  init_state "$ARTIFACT_DIR"
+
+  local json
+  json='{"tool_name":"Write","tool_input":{"file_path":"'"$ARTIFACT_DIR/design.md"'","content":"content"}}'
+
+  run "$HOOK" <<< "$json"
+  [ "$status" -eq 2 ]
+  # stderr (captured in $output when using run without --separate-stderr, but bats merges them)
+  # Check that the block JSON reason is meaningful
+  [[ "$output" == *"goals"* ]]
+  [[ "$output" == *"design"* ]]
+}

--- a/tests/unit/test-setup-project-hooks.bats
+++ b/tests/unit/test-setup-project-hooks.bats
@@ -1,0 +1,228 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Setup: create temp dirs
+setup() {
+  export PROJECT_DIR
+  PROJECT_DIR=$(mktemp -d)
+
+  export PLUGIN_ROOT
+  PLUGIN_ROOT="$(dirname "$BATS_TEST_FILENAME")/../../"
+  # Resolve to absolute path
+  PLUGIN_ROOT="$(cd "$PLUGIN_ROOT" && pwd)"
+
+  export SCRIPT="$PLUGIN_ROOT/hooks/setup-project-hooks.sh"
+  export HOOKS_JSON="$PLUGIN_ROOT/hooks/hooks.json"
+}
+
+teardown() {
+  rm -rf "$PROJECT_DIR"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 1: No existing settings.json → creates with PreToolUse and PostToolUse
+# ──────────────────────────────────────────────────────────────
+@test "no existing settings.json creates file with PreToolUse and PostToolUse" {
+  run "$SCRIPT" "$PROJECT_DIR"
+  [ "$status" -eq 0 ]
+
+  local settings_file="$PROJECT_DIR/.claude/settings.json"
+  [ -f "$settings_file" ]
+
+  local pre
+  pre=$(jq '.hooks.PreToolUse | length' "$settings_file")
+  [ "$pre" -gt 0 ]
+
+  local post
+  post=$(jq '.hooks.PostToolUse | length' "$settings_file")
+  [ "$post" -gt 0 ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 2: No existing settings.json → SessionStart is NOT written
+# ──────────────────────────────────────────────────────────────
+@test "no existing settings.json does not include SessionStart" {
+  run "$SCRIPT" "$PROJECT_DIR"
+  [ "$status" -eq 0 ]
+
+  local settings_file="$PROJECT_DIR/.claude/settings.json"
+  local session
+  session=$(jq '.hooks.SessionStart // "absent"' "$settings_file")
+  [ "$session" = '"absent"' ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 3: Existing settings.json with no hooks → adds hooks section
+# ──────────────────────────────────────────────────────────────
+@test "existing settings.json with no hooks gets hooks section added" {
+  mkdir -p "$PROJECT_DIR/.claude"
+  printf '{"theme":"dark"}\n' > "$PROJECT_DIR/.claude/settings.json"
+
+  run "$SCRIPT" "$PROJECT_DIR"
+  [ "$status" -eq 0 ]
+
+  local settings_file="$PROJECT_DIR/.claude/settings.json"
+  local theme
+  theme=$(jq -r '.theme' "$settings_file")
+  [ "$theme" = "dark" ]
+
+  local pre
+  pre=$(jq '.hooks.PreToolUse | length' "$settings_file")
+  [ "$pre" -gt 0 ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 4: Existing settings.json with other hooks → appends without removing
+# ──────────────────────────────────────────────────────────────
+@test "existing settings.json with other hooks keeps existing and adds QRSPI" {
+  mkdir -p "$PROJECT_DIR/.claude"
+  printf '{"hooks":{"PreToolUse":[{"matcher":"Read","hooks":[{"type":"command","command":"echo read"}]}]}}\n' \
+    > "$PROJECT_DIR/.claude/settings.json"
+
+  run "$SCRIPT" "$PROJECT_DIR"
+  [ "$status" -eq 0 ]
+
+  local settings_file="$PROJECT_DIR/.claude/settings.json"
+  local pre_count
+  pre_count=$(jq '.hooks.PreToolUse | length' "$settings_file")
+  # Should have at least 2 entries (original + QRSPI)
+  [ "$pre_count" -ge 2 ]
+
+  # The original entry must still be present
+  local has_read
+  has_read=$(jq '[.hooks.PreToolUse[].matcher] | map(select(. == "Read")) | length' "$settings_file")
+  [ "$has_read" -ge 1 ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 5: QRSPI hooks already present → running again produces identical output (idempotent)
+# ──────────────────────────────────────────────────────────────
+@test "running script twice is idempotent" {
+  run "$SCRIPT" "$PROJECT_DIR"
+  [ "$status" -eq 0 ]
+
+  local settings_file="$PROJECT_DIR/.claude/settings.json"
+  local first_run
+  first_run=$(jq -c '.' "$settings_file")
+
+  run "$SCRIPT" "$PROJECT_DIR"
+  [ "$status" -eq 0 ]
+
+  local second_run
+  second_run=$(jq -c '.' "$settings_file")
+
+  [ "$first_run" = "$second_run" ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 6: ${CLAUDE_PLUGIN_ROOT} replaced with actual absolute path
+# ──────────────────────────────────────────────────────────────
+@test "CLAUDE_PLUGIN_ROOT variable replaced with absolute path in commands" {
+  run "$SCRIPT" "$PROJECT_DIR"
+  [ "$status" -eq 0 ]
+
+  local settings_file="$PROJECT_DIR/.claude/settings.json"
+
+  # No literal ${CLAUDE_PLUGIN_ROOT} should remain
+  local has_variable
+  has_variable=$(jq '.' "$settings_file" | grep -c '\${CLAUDE_PLUGIN_ROOT}' || true)
+  [ "$has_variable" -eq 0 ]
+
+  # The path should start with /
+  local command_val
+  command_val=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$settings_file")
+  # Should contain an absolute path (starts with /)
+  [[ "$command_val" == *"/"* ]]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 7: Output JSON is valid
+# ──────────────────────────────────────────────────────────────
+@test "output settings.json is valid JSON" {
+  run "$SCRIPT" "$PROJECT_DIR"
+  [ "$status" -eq 0 ]
+
+  local settings_file="$PROJECT_DIR/.claude/settings.json"
+  run jq '.' "$settings_file"
+  [ "$status" -eq 0 ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 8: Explicit project dir argument works
+# ──────────────────────────────────────────────────────────────
+@test "explicit project directory argument is used" {
+  local explicit_dir
+  explicit_dir=$(mktemp -d)
+
+  run "$SCRIPT" "$explicit_dir"
+  [ "$status" -eq 0 ]
+
+  [ -f "$explicit_dir/.claude/settings.json" ]
+  rm -rf "$explicit_dir"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 9: No argument → uses $PWD
+# ──────────────────────────────────────────────────────────────
+@test "no argument uses PWD" {
+  local saved_pwd="$PWD"
+  cd "$PROJECT_DIR"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  [ -f "$PROJECT_DIR/.claude/settings.json" ]
+
+  cd "$saved_pwd"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 10: Exit 0 on success with summary message
+# ──────────────────────────────────────────────────────────────
+@test "exit 0 on success and prints a summary message" {
+  run "$SCRIPT" "$PROJECT_DIR"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 11: Exit 1 if hooks.json is missing
+# ──────────────────────────────────────────────────────────────
+@test "exit 1 when hooks.json cannot be read" {
+  # Run with a fake PLUGIN_ROOT that has no hooks.json
+  local fake_root
+  fake_root=$(mktemp -d)
+  mkdir -p "$fake_root/hooks"
+
+  # We need to override PLUGIN_ROOT detection — do this by creating a wrapper
+  # that calls the script but with the hooks.json path missing
+  # The simplest approach: copy script, patch it to point at fake root
+  local wrapper
+  wrapper=$(mktemp /tmp/test-wrapper-XXXXXX.sh)
+  printf '#!/usr/bin/env bash\nexec "%s" "$@"\n' "$SCRIPT" > "$wrapper"
+  chmod +x "$wrapper"
+
+  # Actually test the script directly: temporarily rename hooks.json
+  local real_hooks_json="$PLUGIN_ROOT/hooks/hooks.json"
+  local backup_hooks_json="$PLUGIN_ROOT/hooks/hooks.json.bak"
+  mv "$real_hooks_json" "$backup_hooks_json"
+
+  run "$SCRIPT" "$PROJECT_DIR"
+  local exit_code="$status"
+
+  # Restore
+  mv "$backup_hooks_json" "$real_hooks_json"
+  rm -f "$wrapper"
+  rm -rf "$fake_root"
+
+  [ "$exit_code" -eq 1 ]
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 12: Script uses set -euo pipefail
+# ──────────────────────────────────────────────────────────────
+@test "setup-project-hooks.sh uses set -euo pipefail" {
+  local script_head
+  script_head=$(head -3 "$SCRIPT")
+  [[ "$script_head" == *"set -euo pipefail"* ]]
+}

--- a/tests/unit/test-state.bats
+++ b/tests/unit/test-state.bats
@@ -1,0 +1,314 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  export TEST_DIR
+  cd "$TEST_DIR"
+}
+
+teardown() {
+  cd /
+  rm -rf "$TEST_DIR"
+}
+
+# Helper function to create a markdown file with frontmatter status
+create_artifact() {
+  local file="$1"
+  local status="$2"
+  local dir="$(dirname "$file")"
+
+  mkdir -p "$dir"
+  cat > "$file" <<EOF
+---
+status: $status
+---
+EOF
+}
+
+# Test: state_init_or_reconcile with approved goals.md + draft design.md
+@test "state_init_or_reconcile: approved goals, draft design -> current_step=questions" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+
+  create_artifact "$artifact_dir/goals.md" "approved"
+  create_artifact "$artifact_dir/design.md" "draft"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  run state_init_or_reconcile "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+
+  # Verify current_step is "questions"
+  local json
+  json=$(state_read)
+  [[ "$json" == *'"current_step":"questions"'* ]]
+
+  # Verify artifact statuses
+  [[ "$json" == *'"goals":"approved"'* ]]
+  [[ "$json" == *'"design":"draft"'* ]]
+}
+
+# Test: state_init_or_reconcile with all approved through plan.md
+@test "state_init_or_reconcile: all approved through plan -> current_step=implement" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+
+  create_artifact "$artifact_dir/goals.md" "approved"
+  create_artifact "$artifact_dir/questions.md" "approved"
+  create_artifact "$artifact_dir/design.md" "approved"
+  create_artifact "$artifact_dir/structure.md" "approved"
+  create_artifact "$artifact_dir/plan.md" "approved"
+
+  # Create research/summary.md
+  mkdir -p "$artifact_dir/research"
+  create_artifact "$artifact_dir/research/summary.md" "approved"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  run state_init_or_reconcile "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+
+  local json
+  json=$(state_read)
+  [[ "$json" == *'"current_step":"implement"'* ]]
+}
+
+# Test: state_init_or_reconcile with empty artifact dir
+@test "state_init_or_reconcile: empty artifact dir -> all draft, current_step=goals" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  run state_init_or_reconcile "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+
+  local json
+  json=$(state_read)
+  [[ "$json" == *'"current_step":"goals"'* ]]
+  [[ "$json" == *'"goals":"draft"'* ]]
+  [[ "$json" == *'"questions":"draft"'* ]]
+  [[ "$json" == *'"research":"draft"'* ]]
+  [[ "$json" == *'"design":"draft"'* ]]
+  [[ "$json" == *'"structure":"draft"'* ]]
+  [[ "$json" == *'"plan":"draft"'* ]]
+  [[ "$json" == *'"implement":"draft"'* ]]
+  [[ "$json" == *'"test":"draft"'* ]]
+}
+
+# Test: state_init_or_reconcile with missing artifact dir
+@test "state_init_or_reconcile: missing artifact dir -> returns 1" {
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  run state_init_or_reconcile "$TEST_DIR/nonexistent"
+
+  [ "$status" -eq 1 ]
+}
+
+# Test: state_read when state exists
+@test "state_read: state exists -> outputs valid JSON, returns 0" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+  create_artifact "$artifact_dir/goals.md" "draft"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  state_init_or_reconcile "$artifact_dir" > /dev/null
+
+  run state_read
+  [ "$status" -eq 0 ]
+
+  # Verify it's valid JSON by checking with jq
+  echo "$output" | jq . > /dev/null
+}
+
+# Test: state_read when no state exists
+@test "state_read: no state -> returns 1" {
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  run state_read
+
+  [ "$status" -eq 1 ]
+}
+
+# Test: state_write_atomic writes valid JSON
+@test "state_write_atomic: writes valid JSON -> file exists with correct content" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+
+  cd "$artifact_dir"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+
+  local test_json='{"version":1,"current_step":"goals"}'
+  run state_write_atomic "$test_json"
+
+  [ "$status" -eq 0 ]
+
+  # Verify file exists
+  [ -f "$artifact_dir/.qrspi/state.json" ]
+
+  # Verify content
+  local content
+  content=$(cat "$artifact_dir/.qrspi/state.json")
+  [[ "$content" == *'"version":1'* ]]
+  [[ "$content" == *'"current_step":"goals"'* ]]
+}
+
+# Test: state_write_atomic creates .qrspi/ if needed
+@test "state_write_atomic: creates .qrspi/ if needed" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+
+  cd "$artifact_dir"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+
+  local test_json='{"version":1}'
+  run state_write_atomic "$test_json"
+
+  [ "$status" -eq 0 ]
+  [ -d "$artifact_dir/.qrspi" ]
+}
+
+# Test: State has version=1
+@test "state_init_or_reconcile: state has version=1" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  state_init_or_reconcile "$artifact_dir" > /dev/null
+
+  local json
+  json=$(state_read)
+  [[ "$json" == *'"version":1'* ]]
+}
+
+# Test: State has correct artifact_dir
+@test "state_init_or_reconcile: state has correct artifact_dir" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  state_init_or_reconcile "$artifact_dir" > /dev/null
+
+  local json
+  json=$(state_read)
+  # artifact_dir should be set to the absolute path
+  [[ "$json" == *'"artifact_dir"'* ]]
+}
+
+# Test: State has wireframe_requested=false
+@test "state_init_or_reconcile: state has wireframe_requested=false" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  state_init_or_reconcile "$artifact_dir" > /dev/null
+
+  local json
+  json=$(state_read)
+  [[ "$json" == *'"wireframe_requested":false'* ]]
+}
+
+# Test: State has active_task=null
+@test "state_init_or_reconcile: state has active_task=null" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  state_init_or_reconcile "$artifact_dir" > /dev/null
+
+  local json
+  json=$(state_read)
+  [[ "$json" == *'"active_task":null'* ]]
+}
+
+# Test: Recognizes all 8 artifacts
+@test "state_init_or_reconcile: recognizes all 8 artifacts" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  state_init_or_reconcile "$artifact_dir" > /dev/null
+
+  local json
+  json=$(state_read)
+
+  # All 8 should be present
+  [[ "$json" == *'"goals"'* ]]
+  [[ "$json" == *'"questions"'* ]]
+  [[ "$json" == *'"research"'* ]]
+  [[ "$json" == *'"design"'* ]]
+  [[ "$json" == *'"structure"'* ]]
+  [[ "$json" == *'"plan"'* ]]
+  [[ "$json" == *'"implement"'* ]]
+  [[ "$json" == *'"test"'* ]]
+}
+
+# Test: Maps research/summary.md to "research" key
+@test "state_init_or_reconcile: maps research/summary.md to research key" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir/research"
+
+  create_artifact "$artifact_dir/research/summary.md" "approved"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  state_init_or_reconcile "$artifact_dir" > /dev/null
+
+  local json
+  json=$(state_read)
+  [[ "$json" == *'"research":"approved"'* ]]
+}
+
+# Test: Library uses set -euo pipefail
+@test "state.sh: starts with #!/usr/bin/env bash" {
+  head -1 "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh" | grep -q '^#!/usr/bin/env bash'
+}
+
+@test "state.sh: has 'set -euo pipefail' as early line" {
+  head -2 "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh" | tail -1 | grep -q '^set -euo pipefail'
+}
+
+# Test: state_init_or_reconcile reads frontmatter correctly from all artifacts
+@test "state_init_or_reconcile: reads frontmatter status from all artifact types" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir/research"
+
+  create_artifact "$artifact_dir/goals.md" "approved"
+  create_artifact "$artifact_dir/questions.md" "approved"
+  create_artifact "$artifact_dir/research/summary.md" "approved"
+  create_artifact "$artifact_dir/design.md" "approved"
+  create_artifact "$artifact_dir/structure.md" "draft"
+  create_artifact "$artifact_dir/plan.md" "draft"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  state_init_or_reconcile "$artifact_dir" > /dev/null
+
+  local json
+  json=$(state_read)
+
+  [[ "$json" == *'"goals":"approved"'* ]]
+  [[ "$json" == *'"questions":"approved"'* ]]
+  [[ "$json" == *'"research":"approved"'* ]]
+  [[ "$json" == *'"design":"approved"'* ]]
+  [[ "$json" == *'"structure":"draft"'* ]]
+  [[ "$json" == *'"plan":"draft"'* ]]
+}
+
+# Test: current_step is first non-approved artifact in pipeline order
+@test "state_init_or_reconcile: current_step is first non-approved in pipeline order" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir/research"
+
+  create_artifact "$artifact_dir/goals.md" "approved"
+  create_artifact "$artifact_dir/questions.md" "approved"
+  create_artifact "$artifact_dir/research/summary.md" "draft"
+  create_artifact "$artifact_dir/design.md" "approved"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  state_init_or_reconcile "$artifact_dir" > /dev/null
+
+  local json
+  json=$(state_read)
+
+  # research is draft, so it should be current_step
+  [[ "$json" == *'"current_step":"research"'* ]]
+}

--- a/tests/unit/test-task.bats
+++ b/tests/unit/test-task.bats
@@ -1,0 +1,332 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_TEMP_DIR="$(mktemp -d)"
+  export ARTIFACT_DIR="$TEST_TEMP_DIR/artifacts"
+  mkdir -p "$ARTIFACT_DIR/tasks"
+  mkdir -p "$TEST_TEMP_DIR/.qrspi"
+
+  # Source the task library for testing
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/task.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+# Helper: Create a task spec file with frontmatter
+create_task_spec() {
+  local file_path="$1"
+  local content="$2"
+  mkdir -p "$(dirname "$file_path")"
+  printf "%s" "$content" > "$file_path"
+}
+
+# ============================================================================
+# task_read_frontmatter tests
+# ============================================================================
+
+@test "task_read_frontmatter: reads all Phase 4 fields correctly" {
+  local task_file="$ARTIFACT_DIR/tasks/task-01.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files:
+  - action: create
+    path: hooks/lib/example.sh
+  - action: modify
+    path: hooks/session-start
+constraints:
+  - Must source frontmatter.sh
+  - No external deps
+---
+
+# Task content here
+"
+
+  output=$(task_read_frontmatter "$task_file")
+
+  # Verify JSON structure
+  echo "$output" | jq . > /dev/null
+
+  # Check enforcement
+  enforcement=$(echo "$output" | jq -r '.enforcement')
+  [[ "$enforcement" == "strict" ]]
+
+  # Check allowed_files array length
+  files_count=$(echo "$output" | jq '.allowed_files | length')
+  [[ "$files_count" == "2" ]]
+
+  # Check first file entry
+  action=$(echo "$output" | jq -r '.allowed_files[0].action')
+  path=$(echo "$output" | jq -r '.allowed_files[0].path')
+  [[ "$action" == "create" ]]
+  [[ "$path" == "hooks/lib/example.sh" ]]
+
+  # Check constraints array length
+  constraints_count=$(echo "$output" | jq '.constraints | length')
+  [[ "$constraints_count" == "2" ]]
+
+  # Check first constraint
+  constraint=$(echo "$output" | jq -r '.constraints[0]')
+  [[ "$constraint" == "Must source frontmatter.sh" ]]
+}
+
+@test "task_read_frontmatter: reads enforcement after status/task/phase fields" {
+  # Regression: enforcement regex must not require ^ anchor (enforcement is not first field)
+  local task_file="$ARTIFACT_DIR/tasks/task-20.md"
+  create_task_spec "$task_file" "---
+status: approved
+task: 20
+phase: 1
+enforcement: strict
+allowed_files:
+  - action: create
+    path: src/main.sh
+constraints: []
+---
+
+# Task 20
+"
+
+  output=$(task_read_frontmatter "$task_file")
+  enforcement=$(echo "$output" | jq -r '.enforcement')
+  [[ "$enforcement" == "strict" ]]
+}
+
+@test "task_read_frontmatter: defaults to strict when enforcement missing (fail-closed)" {
+  local task_file="$ARTIFACT_DIR/tasks/task-02.md"
+  create_task_spec "$task_file" "---
+allowed_files: []
+constraints: []
+---
+
+# Task content
+"
+
+  output=$(task_read_frontmatter "$task_file")
+  enforcement=$(echo "$output" | jq -r '.enforcement')
+  [[ "$enforcement" == "strict" ]]
+}
+
+@test "task_read_frontmatter: returns empty allowed_files when missing" {
+  local task_file="$ARTIFACT_DIR/tasks/task-03.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+constraints: []
+---
+
+# Task content
+"
+
+  output=$(task_read_frontmatter "$task_file")
+  files_count=$(echo "$output" | jq '.allowed_files | length')
+  [[ "$files_count" == "0" ]]
+}
+
+@test "task_read_frontmatter: returns empty constraints when missing" {
+  local task_file="$ARTIFACT_DIR/tasks/task-04.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files: []
+---
+
+# Task content
+"
+
+  output=$(task_read_frontmatter "$task_file")
+  constraints_count=$(echo "$output" | jq '.constraints | length')
+  [[ "$constraints_count" == "0" ]]
+}
+
+@test "task_read_frontmatter: all Phase 4 fields missing returns defaults" {
+  local task_file="$ARTIFACT_DIR/tasks/task-05.md"
+  create_task_spec "$task_file" "---
+title: Some task
+---
+
+# Task content
+"
+
+  output=$(task_read_frontmatter "$task_file")
+  enforcement=$(echo "$output" | jq -r '.enforcement')
+  files_count=$(echo "$output" | jq '.allowed_files | length')
+  constraints_count=$(echo "$output" | jq '.constraints | length')
+
+  [[ "$enforcement" == "strict" ]]
+  [[ "$files_count" == "0" ]]
+  [[ "$constraints_count" == "0" ]]
+}
+
+@test "task_read_frontmatter: nonexistent file returns 1" {
+  run task_read_frontmatter "/nonexistent/file.md"
+  [[ $status == 1 ]]
+}
+
+@test "task_read_frontmatter: multi-entry allowed_files parsed correctly" {
+  local task_file="$ARTIFACT_DIR/tasks/task-06.md"
+  create_task_spec "$task_file" "---
+enforcement: strict
+allowed_files:
+  - action: create
+    path: file1.sh
+  - action: modify
+    path: file2.sh
+  - action: delete
+    path: file3.sh
+constraints: []
+---
+
+# Content
+"
+
+  output=$(task_read_frontmatter "$task_file")
+  files_count=$(echo "$output" | jq '.allowed_files | length')
+  [[ "$files_count" == "3" ]]
+
+  # Verify second entry
+  action=$(echo "$output" | jq -r '.allowed_files[1].action')
+  path=$(echo "$output" | jq -r '.allowed_files[1].path')
+  [[ "$action" == "modify" ]]
+  [[ "$path" == "file2.sh" ]]
+
+  # Verify third entry
+  action=$(echo "$output" | jq -r '.allowed_files[2].action')
+  path=$(echo "$output" | jq -r '.allowed_files[2].path')
+  [[ "$action" == "delete" ]]
+  [[ "$path" == "file3.sh" ]]
+}
+
+# ============================================================================
+# task_get_spec_path tests
+# ============================================================================
+
+@test "task_get_spec_path: zero-pads ID 3 to 03" {
+  output=$(task_get_spec_path 3 "$ARTIFACT_DIR")
+  [[ "$output" == "$ARTIFACT_DIR/tasks/task-03.md" ]]
+}
+
+@test "task_get_spec_path: zero-pads ID 12 to 12" {
+  output=$(task_get_spec_path 12 "$ARTIFACT_DIR")
+  [[ "$output" == "$ARTIFACT_DIR/tasks/task-12.md" ]]
+}
+
+@test "task_get_spec_path: handles single digit correctly" {
+  output=$(task_get_spec_path 1 "$ARTIFACT_DIR")
+  [[ "$output" == "$ARTIFACT_DIR/tasks/task-01.md" ]]
+}
+
+@test "task_get_spec_path: handles double digit correctly" {
+  output=$(task_get_spec_path 99 "$ARTIFACT_DIR")
+  [[ "$output" == "$ARTIFACT_DIR/tasks/task-99.md" ]]
+}
+
+# ============================================================================
+# task_read_runtime_overrides tests
+# ============================================================================
+
+@test "task_read_runtime_overrides: reads existing runtime overrides JSON" {
+  cd "$TEST_TEMP_DIR"
+  mkdir -p .qrspi
+  local json_content='{"status": "passed", "timestamp": "2026-04-07T10:00:00Z"}'
+  printf "%s" "$json_content" > ".qrspi/task-05-runtime.json"
+
+  output=$(task_read_runtime_overrides 5)
+
+  # Verify it's valid JSON
+  echo "$output" | jq . > /dev/null
+
+  # Verify content
+  status=$(echo "$output" | jq -r '.status')
+  [[ "$status" == "passed" ]]
+}
+
+@test "task_read_runtime_overrides: returns 1 when runtime overrides missing" {
+  cd "$TEST_TEMP_DIR"
+  mkdir -p .qrspi
+
+  run task_read_runtime_overrides 7
+  [[ $status == 1 ]]
+}
+
+@test "task_read_runtime_overrides: uses zero-padded task ID" {
+  cd "$TEST_TEMP_DIR"
+  mkdir -p .qrspi
+  local json_content='{"test": "data"}'
+  printf "%s" "$json_content" > ".qrspi/task-03-runtime.json"
+
+  output=$(task_read_runtime_overrides 3)
+  test_val=$(echo "$output" | jq -r '.test')
+  [[ "$test_val" == "data" ]]
+}
+
+# ============================================================================
+# task_write_runtime_overrides tests
+# ============================================================================
+
+@test "task_write_runtime_overrides: writes runtime overrides with correct content" {
+  cd "$TEST_TEMP_DIR"
+
+  local json_data='{"status": "running", "step": 1}'
+  task_write_runtime_overrides 4 "$json_data"
+
+  # Verify file exists and has correct content
+  [[ -f ".qrspi/task-04-runtime.json" ]]
+  content=$(cat ".qrspi/task-04-runtime.json")
+  status=$(echo "$content" | jq -r '.status')
+  [[ "$status" == "running" ]]
+}
+
+@test "task_write_runtime_overrides: creates .qrspi directory if missing" {
+  cd "$TEST_TEMP_DIR"
+  rm -rf .qrspi
+
+  local json_data='{"created": true}'
+  task_write_runtime_overrides 2 "$json_data"
+
+  [[ -d ".qrspi" ]]
+  [[ -f ".qrspi/task-02-runtime.json" ]]
+}
+
+@test "task_write_runtime_overrides: overwrites existing runtime overrides" {
+  cd "$TEST_TEMP_DIR"
+  mkdir -p .qrspi
+
+  printf '{"old": "data"}' > ".qrspi/task-06-runtime.json"
+
+  local json_data='{"new": "data"}'
+  task_write_runtime_overrides 6 "$json_data"
+
+  content=$(cat ".qrspi/task-06-runtime.json")
+  new_val=$(echo "$content" | jq -r '.new')
+  [[ "$new_val" == "data" ]]
+
+  # Old key should not exist
+  ! echo "$content" | jq -e '.old' > /dev/null
+}
+
+@test "task_write_runtime_overrides: uses atomic write (temp + mv)" {
+  cd "$TEST_TEMP_DIR"
+  mkdir -p .qrspi
+
+  local json_data='{"atomic": true}'
+  task_write_runtime_overrides 8 "$json_data"
+
+  # Verify final file exists and is valid
+  [[ -f ".qrspi/task-08-runtime.json" ]]
+  cat ".qrspi/task-08-runtime.json" | jq . > /dev/null
+}
+
+# ============================================================================
+# Library quality tests
+# ============================================================================
+
+@test "task.sh uses set -euo pipefail" {
+  # This test verifies that the script has proper error handling
+  # If it doesn't, the sourcing would have failed
+  [[ -n "${BASH_VERSION}" ]]
+}
+
+@test "task.sh sources frontmatter.sh" {
+  # Verify frontmatter_get_status is available after sourcing task.sh
+  declare -f frontmatter_get_status > /dev/null
+}

--- a/tests/unit/test-validate.bats
+++ b/tests/unit/test-validate.bats
@@ -1,0 +1,452 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  export TEST_DIR
+  cd "$TEST_DIR"
+}
+
+teardown() {
+  cd /
+  rm -rf "$TEST_DIR"
+}
+
+# Helper function to create a markdown file with frontmatter status
+create_artifact() {
+  local file="$1"
+  local status="$2"
+  local dir="$(dirname "$file")"
+
+  mkdir -p "$dir"
+  cat > "$file" <<EOF
+---
+status: $status
+---
+EOF
+}
+
+# Test: validate_state_schema with no state.json creates from artifacts
+@test "validate_state_schema: no state.json -> creates from artifacts, returns 0" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+  create_artifact "$artifact_dir/goals.md" "approved"
+
+  cd "$TEST_DIR"
+  mkdir -p ".qrspi"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_state_schema "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Created state.json from artifacts"* ]]
+  [ -f "$TEST_DIR/.qrspi/state.json" ]
+}
+
+# Test: validate_state_schema with valid v1 returns 0, no output
+@test "validate_state_schema: valid v1 -> returns 0, no output" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+  create_artifact "$artifact_dir/goals.md" "approved"
+
+  cd "$TEST_DIR"
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/state.sh"
+  state_init_or_reconcile "$artifact_dir" > /dev/null
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_state_schema "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# Test: validate_state_schema with missing version migrates to v1
+@test "validate_state_schema: missing version -> migrates to v1" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+  create_artifact "$artifact_dir/goals.md" "approved"
+
+  cd "$TEST_DIR"
+  mkdir -p ".qrspi"
+  # Create v0 state without version field
+  echo '{"current_step":"goals"}' > ".qrspi/state.json"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_state_schema "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Migrated state.json from v0 to v1"* ]]
+
+  # Verify migrated state has version=1
+  local json
+  json=$(cat "$TEST_DIR/.qrspi/state.json")
+  [[ "$json" == *'"version":1'* ]]
+}
+
+# Test: validate_state_schema with missing wireframe_requested repairs
+@test "validate_state_schema: missing wireframe_requested -> repairs" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+  create_artifact "$artifact_dir/goals.md" "approved"
+
+  cd "$TEST_DIR"
+  mkdir -p ".qrspi"
+  # Create v1 state missing wireframe_requested
+  echo '{"version":1,"current_step":"goals","artifact_dir":"'$artifact_dir'","active_task":null,"artifacts":{"goals":"approved","questions":"draft","research":"draft","design":"draft","structure":"draft","plan":"draft","implement":"draft","test":"draft"},"phase_start_commit":null}' > ".qrspi/state.json"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_state_schema "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Repaired: added wireframe_requested"* ]]
+
+  # Verify field was added
+  local json
+  json=$(cat "$TEST_DIR/.qrspi/state.json")
+  [[ "$json" == *'"wireframe_requested":false'* ]]
+}
+
+# Test: validate_state_schema with missing active_task repairs
+@test "validate_state_schema: missing active_task -> repairs" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+  create_artifact "$artifact_dir/goals.md" "approved"
+
+  cd "$TEST_DIR"
+  mkdir -p ".qrspi"
+  # Create v1 state missing active_task
+  echo '{"version":1,"current_step":"goals","artifact_dir":"'$artifact_dir'","wireframe_requested":false,"artifacts":{"goals":"approved","questions":"draft","research":"draft","design":"draft","structure":"draft","plan":"draft","implement":"draft","test":"draft"},"phase_start_commit":null}' > ".qrspi/state.json"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_state_schema "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Repaired: added active_task"* ]]
+
+  # Verify field was added
+  local json
+  json=$(cat "$TEST_DIR/.qrspi/state.json")
+  [[ "$json" == *'"active_task":null'* ]]
+}
+
+# Test: validate_state_schema with missing artifacts rebuilds
+@test "validate_state_schema: missing artifacts -> rebuilds" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+  create_artifact "$artifact_dir/goals.md" "approved"
+
+  cd "$TEST_DIR"
+  mkdir -p ".qrspi"
+  # Create v1 state missing artifacts map
+  echo '{"version":1,"current_step":"goals","artifact_dir":"'$artifact_dir'","wireframe_requested":false,"active_task":null,"phase_start_commit":null}' > ".qrspi/state.json"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_state_schema "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Repaired: rebuilt artifacts from frontmatter"* ]]
+
+  # Verify artifacts map was added
+  local json
+  json=$(cat "$TEST_DIR/.qrspi/state.json")
+  [[ "$json" == *'"artifacts"'* ]]
+  [[ "$json" == *'"goals":"approved"'* ]]
+}
+
+# Test: validate_state_schema outputs migration log
+@test "validate_state_schema: outputs migration log" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+  create_artifact "$artifact_dir/goals.md" "approved"
+
+  cd "$TEST_DIR"
+  mkdir -p ".qrspi"
+  echo '{"current_step":"goals"}' > ".qrspi/state.json"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_state_schema "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+# Test: validate_state_schema uses atomic write
+@test "validate_state_schema: uses atomic write" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+  create_artifact "$artifact_dir/goals.md" "approved"
+
+  cd "$TEST_DIR"
+  mkdir -p ".qrspi"
+  echo '{"current_step":"goals"}' > ".qrspi/state.json"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_state_schema "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  # Verify the final file is valid JSON
+  jq . "$TEST_DIR/.qrspi/state.json" > /dev/null
+}
+
+# Test: validate_config with all fields returns 0
+@test "validate_config: all fields present -> returns 0, no output" {
+  local config_path="$TEST_DIR/config.md"
+  cat > "$config_path" <<'EOF'
+---
+status: draft
+phase: 4
+enforcement_default: strict
+---
+# Config
+EOF
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_config "$config_path"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# Test: validate_config missing Phase 4 fields adds defaults
+@test "validate_config: missing Phase 4 fields -> adds defaults, returns 0" {
+  local config_path="$TEST_DIR/config.md"
+  cat > "$config_path" <<'EOF'
+---
+status: draft
+---
+# Config
+EOF
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_config "$config_path"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"enforcement_default"* ]]
+
+  # Verify field was added to file
+  [[ $(cat "$config_path") == *"enforcement_default"* ]]
+}
+
+# Test: validate_config no file returns 1
+@test "validate_config: no file -> returns 1" {
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_config "$TEST_DIR/nonexistent.md"
+
+  [ "$status" -eq 1 ]
+}
+
+# Test: validate_config preserves existing content
+@test "validate_config: preserves existing content when adding defaults" {
+  local config_path="$TEST_DIR/config.md"
+  cat > "$config_path" <<'EOF'
+---
+status: draft
+---
+# My Config
+
+Some existing content here.
+EOF
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_config "$config_path"
+
+  [ "$status" -eq 0 ]
+  [[ $(cat "$config_path") == *"My Config"* ]]
+  [[ $(cat "$config_path") == *"Some existing content here"* ]]
+}
+
+# Test: validate_config repairs missing frontmatter
+@test "validate_config: no frontmatter -> adds frontmatter with enforcement_default, returns 0" {
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  local config_path="$TEST_DIR/config-no-fm.md"
+  printf 'codex_reviews: false\nsome other content\n' > "$config_path"
+
+  run validate_config "$config_path"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"added missing frontmatter"* ]]
+
+  # File should now have frontmatter with enforcement_default
+  head -1 "$config_path" | grep -q "^---$"
+  grep -q "enforcement_default: strict" "$config_path"
+  # Original content preserved after frontmatter
+  grep -q "codex_reviews: false" "$config_path"
+}
+
+# Test: validate_config repairs empty file
+@test "validate_config: empty file -> adds frontmatter with enforcement_default, returns 0" {
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  local config_path="$TEST_DIR/config-empty.md"
+  touch "$config_path"
+
+  run validate_config "$config_path"
+  [ "$status" -eq 0 ]
+
+  grep -q "enforcement_default: strict" "$config_path"
+}
+
+# Test: validate_task_specs with full specs returns 0, no output
+@test "validate_task_specs: full specs -> returns 0, no output" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir/tasks"
+
+  cat > "$artifact_dir/tasks/task-01.md" <<'EOF'
+---
+status: draft
+task: 1
+phase: 4
+enforcement: strict
+allowed_files:
+  - action: create
+    path: some/file.sh
+constraints:
+  - Some constraint
+---
+Task content
+EOF
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_task_specs "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# Test: validate_task_specs missing enforcement outputs warning
+@test "validate_task_specs: missing enforcement -> warning" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir/tasks"
+
+  cat > "$artifact_dir/tasks/task-01.md" <<'EOF'
+---
+status: draft
+task: 1
+phase: 4
+allowed_files:
+  - action: create
+    path: some/file.sh
+constraints:
+  - Some constraint
+---
+Task content
+EOF
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_task_specs "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"enforcement"* ]]
+}
+
+# Test: validate_task_specs missing allowed_files outputs warning
+@test "validate_task_specs: missing allowed_files -> warning" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir/tasks"
+
+  cat > "$artifact_dir/tasks/task-01.md" <<'EOF'
+---
+status: draft
+task: 1
+phase: 4
+enforcement: strict
+constraints:
+  - Some constraint
+---
+Task content
+EOF
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_task_specs "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"allowed_files"* ]]
+}
+
+# Test: validate_task_specs missing constraints outputs warning
+@test "validate_task_specs: missing constraints -> warning" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir/tasks"
+
+  cat > "$artifact_dir/tasks/task-01.md" <<'EOF'
+---
+status: draft
+task: 1
+phase: 4
+enforcement: strict
+allowed_files:
+  - action: create
+    path: some/file.sh
+---
+Task content
+EOF
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_task_specs "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"constraints"* ]]
+}
+
+# Test: validate_task_specs with no task files returns 0
+@test "validate_task_specs: no task files -> returns 0, no output" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir"
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_task_specs "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# Test: validate_task_specs never modifies files
+@test "validate_task_specs: never modifies files" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir/tasks"
+
+  cat > "$artifact_dir/tasks/task-01.md" <<'EOF'
+---
+status: draft
+task: 1
+phase: 4
+---
+Original content
+EOF
+
+  local original_content
+  original_content=$(cat "$artifact_dir/tasks/task-01.md")
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_task_specs "$artifact_dir"
+
+  local after_content
+  after_content=$(cat "$artifact_dir/tasks/task-01.md")
+
+  [[ "$original_content" == "$after_content" ]]
+}
+
+# Test: validate_task_specs always returns 0
+@test "validate_task_specs: always returns 0" {
+  local artifact_dir="$TEST_DIR/artifacts"
+  mkdir -p "$artifact_dir/tasks"
+
+  cat > "$artifact_dir/tasks/task-01.md" <<'EOF'
+---
+status: draft
+task: 1
+phase: 4
+---
+EOF
+
+  source "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh"
+  run validate_task_specs "$artifact_dir"
+
+  [ "$status" -eq 0 ]
+}
+
+# Test: Library uses set -euo pipefail
+@test "validate.sh: starts with #!/usr/bin/env bash" {
+  head -1 "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh" | grep -q '^#!/usr/bin/env bash'
+}
+
+@test "validate.sh: has 'set -euo pipefail' as early line" {
+  head -2 "$BATS_TEST_DIRNAME/../../hooks/lib/validate.sh" | tail -1 | grep -q '^set -euo pipefail'
+}

--- a/tests/unit/test-worktree.bats
+++ b/tests/unit/test-worktree.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+
+setup() {
+  source $BATS_TEST_DIRNAME/../../hooks/lib/worktree.sh
+  source $BATS_TEST_DIRNAME/../../hooks/lib/protected.sh
+}
+
+# ===== worktree_is_inside tests =====
+
+@test "worktree_is_inside: path inside worktree cwd returns 0" {
+  run worktree_is_inside "/foo/bar" "/foo/bar/file.txt"
+  [ "$status" -eq 0 ]
+}
+
+@test "worktree_is_inside: path outside worktree cwd returns non-zero" {
+  run worktree_is_inside "/foo/bar" "/baz/file.txt"
+  [ "$status" -ne 0 ]
+}
+
+@test "worktree_is_inside: prefix-but-different-dir returns non-zero" {
+  run worktree_is_inside "/foo/bar" "/foo/barbaz/file"
+  [ "$status" -ne 0 ]
+}
+
+# ===== worktree_detect tests =====
+
+@test "worktree_detect: cwd with /.worktrees/ returns 0" {
+  run worktree_detect "/home/user/.worktrees/task-01/src"
+  [ "$status" -eq 0 ]
+}
+
+@test "worktree_detect: cwd without /.worktrees/ returns non-zero" {
+  run worktree_detect "/home/user/project/src"
+  [ "$status" -ne 0 ]
+}
+
+# ===== worktree_extract_task_id tests =====
+
+@test "worktree_extract_task_id: extracts task-03 as 3" {
+  run worktree_extract_task_id "/home/.worktrees/task-03/src/file.sh"
+  [ "$status" -eq 0 ]
+  [ "$output" = "3" ]
+}
+
+@test "worktree_extract_task_id: extracts task-15 as 15" {
+  run worktree_extract_task_id "/home/.worktrees/task-15/subdir/file.sh"
+  [ "$status" -eq 0 ]
+  [ "$output" = "15" ]
+}
+
+@test "worktree_extract_task_id: extracts task ID from PWD without trailing slash" {
+  run worktree_extract_task_id "/home/.worktrees/task-07"
+  [ "$status" -eq 0 ]
+  [ "$output" = "7" ]
+}
+
+@test "worktree_extract_task_id: non-worktree path returns error" {
+  run worktree_extract_task_id "/home/user/project/file.sh"
+  [ "$status" -ne 0 ]
+}
+
+# ===== protected_is_blocked tests =====
+
+@test "protected_is_blocked: tasks/task-05.md in worktree is blocked" {
+  run protected_is_blocked "tasks/task-05.md" 0
+  [ "$status" -eq 0 ]
+}
+
+@test "protected_is_blocked: .qrspi/state.json in worktree is blocked" {
+  run protected_is_blocked ".qrspi/state.json" 0
+  [ "$status" -eq 0 ]
+}
+
+@test "protected_is_blocked: .qrspi/task-03-runtime.json in worktree is blocked" {
+  run protected_is_blocked ".qrspi/task-03-runtime.json" 0
+  [ "$status" -eq 0 ]
+}
+
+@test "protected_is_blocked: config.md in worktree is blocked" {
+  run protected_is_blocked "config.md" 0
+  [ "$status" -eq 0 ]
+}
+
+@test "protected_is_blocked: .qrspi/audit-task-03.jsonl in worktree is blocked" {
+  run protected_is_blocked ".qrspi/audit-task-03.jsonl" 0
+  [ "$status" -eq 0 ]
+}
+
+@test "protected_is_blocked: reviews/alignment/report.md in worktree is blocked" {
+  run protected_is_blocked "reviews/alignment/report.md" 0
+  [ "$status" -eq 0 ]
+}
+
+@test "protected_is_blocked: hooks/lib/task.sh in worktree is not blocked" {
+  run protected_is_blocked "hooks/lib/task.sh" 0
+  [ "$status" -ne 0 ]
+}
+
+@test "protected_is_blocked: any path not in worktree is not blocked" {
+  run protected_is_blocked "tasks/task-05.md" 1
+  [ "$status" -ne 0 ]
+}
+
+# ===== Library structure tests =====
+
+@test "worktree.sh uses set -euo pipefail" {
+  grep -q "set -euo pipefail" $BATS_TEST_DIRNAME/../../hooks/lib/worktree.sh
+}
+
+@test "protected.sh uses set -euo pipefail" {
+  grep -q "set -euo pipefail" $BATS_TEST_DIRNAME/../../hooks/lib/protected.sh
+}
+
+@test "worktree.sh does not source other libraries" {
+  # Check that no 'source' or '. ' statements exist (excluding shebang and comments)
+  ! grep -E "^\s*(source|\.)\s" $BATS_TEST_DIRNAME/../../hooks/lib/worktree.sh
+}
+
+@test "protected.sh does not source other libraries" {
+  # Check that no 'source' or '. ' statements exist (excluding shebang and comments)
+  ! grep -E "^\s*(source|\.)\s" $BATS_TEST_DIRNAME/../../hooks/lib/protected.sh
+}


### PR DESCRIPTION
## Summary

- **Pipeline step ordering enforcement** — PreToolUse hook blocks artifact writes that skip prerequisites (e.g., writing design.md before goals.md is approved). Checks frontmatter status as ground truth, not just state.json.
- **L1 task boundary enforcement** — Strict mode blocks file writes outside the task's allowlist. Monitored mode logs but allows. Runtime overrides let users approve additional files mid-task.
- **Audit logging** — PostToolUse logs all Write/Edit/Bash calls to per-task JSONL files with timestamps, enforcement mode, and in-scope status. Errors logged to general audit.jsonl.
- **Fail-closed security model** — All enforcement error paths block with actionable messages. Missing state, corrupted JSON, unreadable files all produce user-visible errors, never silent pass-through.
- **276 tests** (204 unit + 72 acceptance), all passing.
- **16 design amendments** captured for Phase 2 replan (full enforcement stack, bash-detect improvements, code consolidation).

## What's included

### Hooks
- `pre-tool-use` — pipeline ordering + L1 allowlist enforcement (blocking)
- `post-tool-use` — artifact state sync + audit logging (non-blocking)
- `session-start` — skill injection only
- `setup-project-hooks.sh` — workaround for Claude Code bug #17688

### Libraries (hooks/lib/)
- `artifact.sh` — artifact detection + state sync with change detection
- `audit.sh` — JSONL audit log writer
- `bash-detect.sh` — regex-based file-write target extraction from bash commands
- `enforcement.sh` — L1 allowlist checking with runtime overrides
- `frontmatter.sh` — YAML frontmatter status parser
- `pipeline.sh` — step ordering and prerequisite checking
- `protected.sh` — infrastructure file protection in worktrees
- `state.sh` — state.json management with atomic writes
- `task.sh` — task spec frontmatter reader
- `validate.sh` — state schema migration and config repair
- `worktree.sh` — worktree detection and task ID extraction

### Tests
- 12 unit test files (204 tests)
- 4 acceptance test files (72 tests): pipeline ordering, enforcement, audit logging, meta

## Test plan

- [x] All 276 tests pass (204 unit + 72 acceptance)
- [x] Full code review loop (Claude + Codex) — 4 rounds until clean
- [x] Silent failure audit — all enforcement paths verified fail-closed
- [x] User code review — security issues, naming, architecture reviewed
- [ ] Dogfood: use enforcement during Phase 2 implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
