### PR TITLE
v0.5 spec round 3: #99+#40, #118+#115, #125 specs

### DIFF
--- a/docs/superpowers/specs/2026-05-05-118-115-interactive-skill-ux-bundle-design.md
+++ b/docs/superpowers/specs/2026-05-05-118-115-interactive-skill-ux-bundle-design.md
@@ -1,0 +1,126 @@
+# Interactive-Skill UX Bundle: #118 Per-Goal Design + Auto-Mode + #115 Per-Researcher Dispatch Refinements
+
+**Status:** Design
+**Issues:** [#118](https://github.com/dfrysinger/qrspi-plus/issues/118), [#115](https://github.com/dfrysinger/qrspi-plus/issues/115)
+**Milestone:** v0.5
+**Date:** 2026-05-05
+
+## 1. Bundle Rationale
+
+Both issues refine **interactive-skill prompt language** — collaborative-skill UX (#118) and per-researcher dispatch prompts (#115). Each issue is itself a 2-pack of small refinements, so the spec totals four discrete prose-edits to three SKILL.md files.
+
+The two issues are independent (different SKILLs, different concerns) but share the shape: adjust prompt prose at specific dispatch/preamble sites, no schema change. Bundling avoids two near-identical small PRs.
+
+Per the qrspi-plus prose-handling preference: skip full reviewer suite, decide test handling per change, no TDD ceremony.
+
+## 2. #118: Per-Goal Design + Auto-Mode Detection
+
+### 2.1 Refinement A — Per-goal Design brainstorming
+
+**Problem.** v0.4-bundle had 13 goals (G1-G13). `design/SKILL.md` § Interactive Design Discussion currently prescribes "Propose 2-3 design approaches with trade-offs, lead with recommendation" without sequencing per-goal. Opening the floor to a 13-goal design dump produces shallow buy-in. Goal-by-goal Q&A produces deeper alignment.
+
+**Site.** `skills/design/SKILL.md:45` — `### Interactive Design Discussion`.
+
+**Fix shape.** Replace the current step-1 prescription with a per-goal loop:
+
+> 1. **For each goal in `goals.md`, in order:**
+>    1. Surface the relevant research findings from `research/summary.md` (and on-demand from `research/q*.md` if a decision depends on details).
+>    2. Propose 2–3 candidate approaches; lead with recommendation; explain trade-offs.
+>    3. Open Q&A — user asks back, you ask back, until the goal's design is settled.
+>    4. Move to the next goal. Do **not** dump multiple goals' designs in one turn.
+
+Existing steps 2–5 (test strategy, mermaid diagram, key decisions, amendment handling) remain — they're cross-cutting concerns finalized after per-goal discussion settles. Renumber them as the post-loop second phase.
+
+**Add Red Flag entry** to the Red Flags section (at end of design/SKILL.md):
+
+> Batch-presenting designs for multiple goals in one turn — pace the discussion goal-by-goal.
+
+### 2.2 Refinement B — Auto-mode detection in Goals + Design
+
+**Problem.** Goals and Design are collaborative interactive skills. Auto-mode rules ("minimize interruptions, prefer action over planning") subvert the collaboration — the agent is told to skip the turn-by-turn dialogue these skills depend on.
+
+**Sites.**
+- `skills/goals/SKILL.md:10` — preamble after `**Announce at start:**`
+- `skills/design/SKILL.md:10` — preamble after `**Announce at start:**`
+
+**Fix shape.** Add a new bullet immediately after the announce line in both SKILLs:
+
+> **If auto-mode is detected** (presence of `## Auto Mode Active` system-reminder in current context), surface to the user before the first interactive step: "This skill is collaborative — turn-by-turn dialogue produces better {Goals/Design} quality than autonomous execution. Recommend exiting auto-mode (`Esc` → off) for this phase. I'll proceed in either mode if you prefer."
+>
+> Do not force the user out of auto-mode; respect their choice. Surface the recommendation explicitly at start.
+
+The recommendation is a one-time surface at skill start, not repeated mid-skill.
+
+## 3. #115: Per-Researcher Dispatch Refinements
+
+### 3.1 Refinement A — Direct-write is the unambiguous default (G13)
+
+**Problem.** During the 2026-04-29 v0.4-bundle Research stage, ~200KB of per-question research was routed back through main chat as text-return then re-emitted via `Write` — likely defensive over-fencing against the F-8 binary subagent worktree wall. User observed: "very slow and context heavy."
+
+**Status (verified by reading current research/SKILL.md).** The SKILL already prescribes direct writes for `research/q*.md` (line 52: "Each subagent writes its own report directly to `{ABS_RESEARCH_DIR}/q{NN}-{type}.md` using the `Write` tool. The orchestrator passes the absolute path into the subagent prompt; subagents do NOT return findings as text."). The defect was at the dispatch-prompt-shape level, not the SKILL design.
+
+**Site.** `skills/research/SKILL.md` § Per-Researcher Subagent → Dispatch parameters list (around line 60–66).
+
+**Fix shape.** Tighten the dispatch parameters subsection by adding an explicit short paragraph immediately after the parameters list:
+
+> **Direct-write contract (unambiguous default).** Per-researcher subagents write their `q*.md` report directly to `output_path` via the `Write` tool. They do **not** return report content as text. Text-return is not used anywhere in the research pipeline — the collation subagent also direct-writes (to the `research/_collated.md` staging filename, which the orchestrator then renames to `research/summary.md`). The staging-filename pattern exists precisely to avoid text-return through main chat. If the orchestrator ever omits `output_path` from a per-researcher dispatch, that is a dispatch defect — fix the orchestrator, do not fall back to text-return.
+
+This pins the contract in dispatch-side prose so future re-templating cannot regress to defensive text-return.
+
+### 3.2 Refinement B — Summary block authored last, placed first
+
+**Problem.** Per-question `research/q*.md` files carry a structured summary block (TL;DR / key findings / surprises / caveats per #95 / G10) at the **top**. Researcher subagents reading the file template top-down may be tempted to write the summary block first — generating it from intent rather than completed findings.
+
+**Site.** `skills/research/SKILL.md` § Per-Researcher Subagent — wherever the per-question report template (or pointer to it in the agent body `agents/qrspi-research-specialist.md`) is referenced.
+
+**Fix shape.** Add an explicit instruction line in the dispatch parameters area (or just below §3.1's direct-write paragraph):
+
+> **Summary-last authoring order.** The per-question report template places the structured summary block (TL;DR / key findings / surprises / caveats) at the **top** of the file — that is the consumer-facing reading order. Authoring order is the inverse: investigate first, draft the full report body, then author the summary block **last**, then place it at the top of the file. Do not generate the summary from intent before the body is complete.
+
+Pair with a one-line reminder comment in the report-template scaffold (in `agents/qrspi-research-specialist.md` — verify exact site during implementation).
+
+## 4. Test Handling
+
+Per qrspi-plus prose-handling memory: decide test handling per change.
+
+| Refinement | Test surface | Decision |
+|---|---|---|
+| §2.1 per-goal Design loop | Reviewer prose-grep against `For each goal in goals.md` literal in design/SKILL.md | **Skip.** Mechanical content; dialogue ordering is verified at runtime by user, not by static check. |
+| §2.2 auto-mode detection (Goals + Design) | Static grep for `Auto Mode Active` literal in both SKILLs | **Add minimal grep guard.** Two-assertion bats test: each SKILL's preamble contains the auto-mode detection paragraph. Cheap to write, catches regression. |
+| §3.1 direct-write contract pin | Static grep for "Direct-write contract" header in research/SKILL.md dispatch section | **Add minimal grep guard.** One assertion: research/SKILL.md contains the header literal. Cheap; catches accidental deletion in future edits. |
+| §3.2 summary-last instruction | Static grep for "Summary-last" header | **Same as §3.1** — add to the same bats file. |
+
+**Single new bats file:** `tests/unit/test-interactive-skill-prompts.bats` — 3 assertions total (auto-mode in goals, auto-mode in design, direct-write + summary-last in research).
+
+## 5. Sequence
+
+Single PR. Two commits (group by issue):
+
+1. **`docs(research): #115 per-researcher dispatch prompt refinements`** — direct-write contract paragraph + summary-last instruction in research/SKILL.md, plus the research-specialist agent-body reminder line.
+2. **`docs(goals,design): #118 per-goal Design + auto-mode detection`** — per-goal loop in design/SKILL.md, auto-mode preamble in goals/SKILL.md + design/SKILL.md, Red Flag entry in design/SKILL.md, plus the new bats guard file (covers both issues).
+
+The bats file lands in commit 2 because that commit is the larger surface change; if landed in commit 1 the auto-mode assertions would fail until commit 2 lands.
+
+Test plan:
+- `bats tests/unit/test-interactive-skill-prompts.bats` — 3 assertions pass.
+- `bats tests/unit/` — full suite green.
+- Manual scan: open design/SKILL.md and verify the per-goal loop reads naturally with surrounding context.
+
+## 6. Backwards Compatibility
+
+Pure prose. No agent file, schema, or routing impact.
+
+The per-goal Design loop changes the **shape** of the discussion the orchestrator runs at runtime; existing in-flight design conversations do not exist as persisted state, so there's no migration. New conversations use the new shape.
+
+The auto-mode detection adds a new soft surface — if no `## Auto Mode Active` system-reminder is present, the detection paragraph instructs no action and the skill proceeds normally.
+
+## 7. Out of Scope
+
+- **Auto-mode detection in non-interactive skills** (Questions, Research, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test). Those run as subagent pipelines; auto-mode is appropriate. Explicitly not extended in this PR.
+- **File layout changes for `research/q*.md`** — summary block stays at the top (it's the right consumer-facing layout). Only the authoring-order instruction changes.
+- **Collation subagent's text-return pattern** — still required for `summary.md` per the CC 2.1.x guardrail. §3.1 explicitly preserves this exception.
+
+## 8. Closes
+
+- Closes #118
+- Closes #115

--- a/docs/superpowers/specs/2026-05-05-125-deferred-reviewer-migration-design.md
+++ b/docs/superpowers/specs/2026-05-05-125-deferred-reviewer-migration-design.md
@@ -177,6 +177,7 @@ The squash merges these into one cutover commit on main. Developmentally splitti
 - **Extending the `scope_tag` field** (#112) — not a precondition for cutover. Lands in a separate PR after #125 merges.
 - **Renaming `round-NN-fixes.md` → `round-NN-dispositions.md`** (#113) — the `round-NN-fixes.md` filename is the fix-round per-finding-disposition file, downstream of reviewer findings. Independent of this migration.
 - **Adding new reviewer tags or splitting existing ones.** Migration only — preserves the current reviewer-tag set.
+- **Centralizing duplicated reviewer-dispatch wrapper-marker boilerplate via `!cat`** (#130, v0.6) — the wrapper-marker prose duplicated across Plan/Implement/Integrate/Test/Replan lives on different lines than what this cutover edits. Folding it in would roughly double the diff and review burden. Cleaner sequencing: #125 atomic cutover lands first, #130 refactors the centralization on top.
 - **Performance work** on the parallel-dispatch fan-out. Per-finding emission is structurally faster than legacy single-file (no rewriting one file per finding) but quantifying that is not a §10 deliverable.
 
 ## 11. Closes

--- a/docs/superpowers/specs/2026-05-05-125-deferred-reviewer-migration-design.md
+++ b/docs/superpowers/specs/2026-05-05-125-deferred-reviewer-migration-design.md
@@ -1,0 +1,191 @@
+# Deferred Reviewer Migration: Per-Finding Emission + Reviewer-Protocol Bifurcation Collapse
+
+**Status:** Design
+**Issue:** [#125](https://github.com/dfrysinger/qrspi-plus/issues/125)
+**Milestone:** v0.5
+**Date:** 2026-05-05
+**Predecessor:** [#109 — Sonnet→Haiku confidence verifier](2026-05-04-109-sonnet-haiku-verifier-design.md) — established the per-finding contract and migrated 14 of 32 reviewer-class agents.
+
+## 1. Overview
+
+#109 introduced the per-finding disk-write contract and migrated 14 reviewers (8 quality + 6 scope) for `goals/questions/research/design/phasing/structure/parallelize/replan`. The remaining 18 reviewers — Plan-stage, per-task, and integration-class — still use the legacy single-file-per-reviewer contract (`reviews/{step}/round-NN-{reviewer-tag}.md`). The reviewer-protocol skill carries both contracts in parallel.
+
+This issue migrates all 18 deferred reviewers to per-finding emission in a **single atomic cutover commit**, then collapses the reviewer-protocol bifurcation back to a single per-finding contract.
+
+## 2. Atomicity Constraint
+
+**The cutover is one commit.** Splitting it across commits would produce a runtime state where a single Plan review round dispatches reviewers using mixed contracts: some emit per-finding files, some emit a single legacy file. The apply-fix protocol's schema-violation guard (#109) cannot reason about a mixed round — it expects either per-finding files OR no output (the clean-sentinel case) for every expected reviewer tag in `## Expected-Reviewer Matrix`. A mixed round corrupts the matrix.
+
+**Why Plan in particular.** Plan's review round dispatches up to 7 Claude reviewers in parallel (unified plan-quality + 5 plan-artifact + scope-reviewer) plus 7 Codex parallels. Currently 0/7 use per-finding emission. After cutover: 7/7. The transition window must be one commit because Plan re-runs that hit the window mid-edit dispatch one tag's reviewer with the new contract and another tag's reviewer with the old, against a shared `reviews/plan/round-NN/` directory.
+
+**Implementation discipline.** All agent-file edits + all dispatching-SKILL edits + the reviewer-protocol edit + the test updates land in **one squash-merged PR with one final commit** (development can use multiple commits during PR iteration; the merge is a single commit on main).
+
+## 3. Migration Scope
+
+### 3.1 Deferred reviewers (18 agent files)
+
+Verified by listing `agents/qrspi-*reviewer*.md` + `qrspi-*hunter*.md` + `qrspi-*analyzer*.md` + `qrspi-code-simplifier.md`, subtracting the 14 already-migrated #109 reviewers:
+
+**Plan-artifact reviewers (5):**
+- `agents/qrspi-plan-spec-reviewer.md`
+- `agents/qrspi-plan-security-reviewer.md`
+- `agents/qrspi-plan-goal-traceability-reviewer.md`
+- `agents/qrspi-plan-test-coverage-reviewer.md`
+- `agents/qrspi-plan-silent-failure-hunter.md`
+
+**Unified plan quality + scope (2):**
+- `agents/qrspi-plan-reviewer.md`
+- `agents/qrspi-plan-scope-reviewer.md`
+
+**Per-task reviewers (8):**
+- `agents/qrspi-spec-reviewer.md`
+- `agents/qrspi-code-quality-reviewer.md`
+- `agents/qrspi-security-reviewer.md`
+- `agents/qrspi-goal-traceability-reviewer.md`
+- `agents/qrspi-test-coverage-reviewer.md`
+- `agents/qrspi-silent-failure-hunter.md`
+- `agents/qrspi-type-design-analyzer.md`
+- `agents/qrspi-code-simplifier.md`
+
+**Implement-gate (1):**
+- `agents/qrspi-implement-gate-reviewer.md`
+
+**Integration-class (2):**
+- `agents/qrspi-integration-reviewer.md`
+- `agents/qrspi-security-integration-reviewer.md`
+
+**Total: 18 agent files.**
+
+### 3.2 Per-agent edit shape
+
+Each agent file currently contains either explicit single-file legacy contract prose or a reference to "the disk-write contract from the reviewer-protocol skill" that resolves to `## Legacy Disk-Write Contract` via the routing table. Since the routing table goes away in this cutover (§4.1), the edit shape per agent depends on what's in the file today:
+
+**If the agent body cites a specific path pattern** (e.g., `Output file: reviews/{step}/round-NN-{reviewer-tag}.md`): replace with `reviews/{step}/round-NN/<reviewer_tag>.finding-F<NN>.md` per-finding pattern + clean-sentinel reference.
+
+**If the agent body just defers to the protocol** (e.g., the audited `qrspi-plan-reviewer.md` body says "conforming to the disk-write contract from the reviewer-protocol skill"): no agent-file edit needed for the contract — the protocol redirect resolves to the new (single, unified) per-finding contract once §4.1 lands.
+
+**Audit pass during implementation.** For each of the 18 agent files, grep for `round-NN-` and explicit legacy-shape language. Files with no path-specific prose need no edit; files with path-specific prose need surgical updates.
+
+## 4. Reviewer-Protocol Skill Updates
+
+### 4.1 Bifurcation collapse
+
+**Sections affected:** `skills/reviewer-protocol/SKILL.md`
+
+| Section | Current state (pre-cutover) | Post-cutover |
+|---|---|---|
+| `## Reviewer-Tag Routing Table` (lines 19–29) | Bifurcates by tag, points to two contract sections | **Removed.** No bifurcation; one contract. |
+| `## Expected-Reviewer Matrix` (lines 31–46) | Covers 8 #109 steps only; line 46 says "Plan, Implement-gate, Integrate, Test are out of scope for #109 — see follow-up issue." | **Extended** to cover Plan, Implement-gate, Integrate, Test. Line 46's parenthetical is removed. |
+| `## Legacy Disk-Write Contract (deferred reviewers)` (lines 160–202) | The legacy single-file contract | **Removed in entirety.** |
+| `## Per-Finding Disk-Write Contract (#109 reviewers)` (lines 204–256) | The per-finding contract, qualified to #109 reviewers | **Renamed** to `## Per-Finding Disk-Write Contract`. The "(#109 reviewers)" qualifier is removed. Otherwise the section is unchanged — its prose already covers all reviewer tags now that no others remain. |
+
+**Cross-references updated.** Lines that mention the bifurcation (e.g., line 21's "The reviewer protocol bifurcates during the #109 migration window") are removed or rewritten.
+
+### 4.2 Expected-Reviewer Matrix extension
+
+The matrix table gets new rows for Plan, Implement-gate, Integrate, Test. Each row's expected tags are derived from the dispatching SKILL today:
+
+| Step | `codex_reviews: true` | `codex_reviews: false` |
+|---|---|---|
+| `plan` | `quality-claude`, `scope-claude`, plus 5 plan-artifact reviewer tags (`plan-spec-claude`, `plan-security-claude`, `plan-goal-traceability-claude`, `plan-test-coverage-claude`, `plan-silent-failure-hunter-claude`) and their Codex counterparts where applicable | claude-only equivalents |
+| `implement-gate` | `implement-gate-claude`, `implement-gate-codex` | `implement-gate-claude` |
+| `integrate` | `integration-claude`, `security-integration-claude`, plus Codex counterparts | claude-only equivalents |
+| `test` | `test-coverage-claude`, plus Codex counterpart | `test-coverage-claude` |
+
+**Authoritative source for tag names.** During implementation, derive each tag from the dispatching SKILL.md — these names must match what the dispatcher actually passes as `reviewer_tag`. The table above is illustrative; the implementer reconciles against grep of dispatcher SKILLs before writing the final table.
+
+## 5. Dispatching-SKILL Updates
+
+The dispatching skills that currently emit legacy single-file output paths must switch to per-finding round-directory paths in their reviewer dispatch logic.
+
+**Sites to audit + edit** (verified by `grep -lE 'round-NN-\{|Output file:.*round-NN-'`):
+
+- `skills/plan/SKILL.md` — Plan reviewer dispatch (7 Claude + 7 Codex sites)
+- `skills/implement/SKILL.md` — per-task reviewer dispatch (8 Claude + Codex parallels per task) and implement-gate dispatch
+- `skills/integrate/SKILL.md` — integration + security-integration dispatch
+- `skills/test/SKILL.md` — test-coverage dispatch
+- `skills/replan/SKILL.md` — verify already-migrated state; the replan-reviewer was migrated by #109 but the SKILL may carry residual legacy-shape prose for adjacent reviewers
+- `skills/using-qrspi/SKILL.md` — `## Review Output Handling` doc; update to drop the bifurcation reference
+
+**Edit shape (per dispatch site).** Replace the `Output file: reviews/{step}/round-NN-{reviewer-tag}.md` parameter with `Output directory: reviews/{step}/round-NN/` (the reviewer constructs the per-finding filename per the protocol contract).
+
+## 6. Test Updates
+
+Per #125 issue body, four tests added by #109 currently skip the deferred reviewers with a comment citing this issue number. They must extend on cutover:
+
+- `tests/unit/test-per-finding-file-emission.bats` (test #2 in #109 plan)
+- `tests/unit/test-clean-sentinel-and-schema-guard.bats` (test #4)
+- `tests/unit/test-change-type-partition.bats` (test #6)
+- `tests/unit/test-failure-menu.bats` (test #10)
+
+**Edit shape (per test):** remove the deferred-reviewer skip block; extend assertions to iterate over the full reviewer-tag set including the 18 newly-migrated tags. The fixture set in `tests/fixtures/issue-109/` may need new fixtures for plan/implement-gate/integrate/test rounds — assess during implementation.
+
+**New test:** `tests/unit/test-no-legacy-disk-write-references.bats` — grep guard:
+
+```bash
+@test "no agent file references the legacy round-NN-{tag}.md path pattern" {
+  local offenders
+  offenders=$(grep -rE 'round-NN-\{?[a-z-]+\}?\.md' agents/ skills/ \
+    | grep -v 'reviewer-protocol/SKILL.md' \
+    || true)
+  if [ -n "$offenders" ]; then
+    echo "legacy single-file path references remain:"
+    echo "$offenders"
+    return 1
+  fi
+}
+
+@test "reviewer-protocol skill carries no Legacy Disk-Write Contract section" {
+  ! grep -qE '^## Legacy Disk-Write Contract' skills/reviewer-protocol/SKILL.md
+}
+
+@test "reviewer-protocol skill carries no Reviewer-Tag Routing Table" {
+  ! grep -qE '^## Reviewer-Tag Routing Table' skills/reviewer-protocol/SKILL.md
+}
+```
+
+Three assertions, ~25 lines of bats. Catches future regression to the bifurcated state.
+
+## 7. Sequence
+
+**Single PR.** Single squash-merged commit on main (per §2). During PR development the work can split across commits for reviewability:
+
+1. **`refactor(agents): migrate 18 deferred reviewers to per-finding contract`** — touches the agent files in §3.1.
+2. **`refactor(skills): switch dispatching skills to per-finding output paths`** — Plan/Implement/Integrate/Test/Replan/using-qrspi.
+3. **`refactor(reviewer-protocol): collapse bifurcation`** — drops Legacy section, Routing Table; renames per-finding section; extends matrix.
+4. **`test: extend per-finding tests + add legacy-pattern guard`** — updates the four #109 tests, adds the new grep guard test.
+
+The squash merges these into one cutover commit on main. Developmentally splitting them is fine; **squashing on merge is required**.
+
+## 8. Test Plan
+
+- Full bats suite green: `bats tests/unit/`
+- New legacy-pattern grep guard passes
+- Existing #109 tests extended and passing across all 32 reviewer tags
+- Manual smoke (deferred to a v0.5 follow-up review run): one Plan review round in a real artifact dir produces a `reviews/plan/round-NN/` directory with per-finding files for every expected tag, no legacy `round-NN-{tag}.md` files written
+
+## 9. Backwards Compatibility
+
+**None preserved.** The cutover is breaking by design — the bifurcation existed only to permit incremental #109 migration, and #125 closes that window.
+
+**In-flight artifact dirs.** A `reviews/{step}/` directory authored before cutover contains legacy `round-NN-{reviewer-tag}.md` files. After cutover, new rounds in the same artifact dir create `round-NN+1/` per-finding directories. Reading older legacy rounds is not affected — they remain on disk untouched. The apply-fix protocol only reads the most recent round; it does not need to interpret older rounds in the new shape.
+
+**Fix-round dispatches mid-rebase.** A user rebasing a review-round branch onto the cutover commit must restart the in-flight review round from scratch (a fresh round on the new contract). Mid-round files cannot mix contracts. Document this in the commit message and PR body.
+
+## 10. Out of Scope
+
+- **Extending the `scope_tag` field** (#112) — not a precondition for cutover. Lands in a separate PR after #125 merges.
+- **Renaming `round-NN-fixes.md` → `round-NN-dispositions.md`** (#113) — the `round-NN-fixes.md` filename is the fix-round per-finding-disposition file, downstream of reviewer findings. Independent of this migration.
+- **Adding new reviewer tags or splitting existing ones.** Migration only — preserves the current reviewer-tag set.
+- **Performance work** on the parallel-dispatch fan-out. Per-finding emission is structurally faster than legacy single-file (no rewriting one file per finding) but quantifying that is not a §10 deliverable.
+
+## 11. Closes
+
+- Closes #125
+
+## 12. Open Questions for User
+
+(Surfaced for explicit confirmation before implementation begins, since this is the largest spec in the v0.5 spec round.)
+
+- **§4.2 Expected-Reviewer Matrix tag names.** The illustrative names (`plan-spec-claude`, `implement-gate-claude`, `test-coverage-claude`, etc.) may not match what the dispatchers currently pass. Implementer reconciles by grep — flagging here in case any tag rename is desired during this cutover (recommended: no, keep cutover migration-only per §10).
+- **§9 in-flight rebase guidance.** Does this need explicit bats coverage, or is the commit-message + PR-body warning sufficient? Recommended: warning only — automated coverage of mid-rebase user behavior isn't a thing.

--- a/docs/superpowers/specs/2026-05-05-99-40-prose-sweep-bundle-design.md
+++ b/docs/superpowers/specs/2026-05-05-99-40-prose-sweep-bundle-design.md
@@ -1,0 +1,229 @@
+# Prose-Sweep Bundle: #99 Compaction-Prompt Imperative + #40 LOC-Ceiling Clarification
+
+**Status:** Design
+**Issues:** [#99](https://github.com/dfrysinger/qrspi-plus/issues/99), [#40](https://github.com/dfrysinger/qrspi-plus/issues/40)
+**Milestone:** v0.5
+**Date:** 2026-05-05
+
+## 1. Bundle Rationale
+
+Both issues are cross-cutting prose clarifications with no schema, routing, or runtime impact. Both target SKILL.md prose surfaces. Bundling into one PR avoids reviewing two near-identical "audit and edit prose" PRs back-to-back; neither is large enough to warrant its own spec round.
+
+Per the qrspi-plus prose-handling preference: skip full reviewer suite, decide test handling per change, no TDD ceremony.
+
+## 2. #99: Compaction-Prompt Imperative Sweep
+
+### 2.1 Problem
+
+QRSPI SKILLs carry "compaction recommended" notes scattered across ~12 SKILL.md files at four overlapping transition points (pre-large-subagent-dispatch, pre-review-loop, terminal-state, cross-skill-transition). In a real v0.4-bundle session (2026-04-29), the orchestrator skipped every applicable trigger across the Research stage. Four reasons the current shape fails:
+
+1. **Conditional + no instrument.** The notes say "if context utilization may exceed ~50%" but the agent has no telemetry for current utilization. Soft conditional + no signal → "probably fine, keep going."
+2. **Blockquote reads as advisory.** `> **IMPORTANT — Compaction recommended.** ...` reads as a side-note. Compare to `<HARD-GATE>` blocks at the top of skill files — those have teeth.
+3. **Auto-mode pressure.** Auto-mode rules tell the agent to "minimize interruptions, prefer action." Recommending /compact is exactly the pause auto-mode is told to skip.
+4. **Duplicated prose, drift risk.** The same Iron Rule shape ("do not skip this check") is repeated inconsistently across SKILLs. The pre-review-loop site in Plan has it; the pre-fanout site in Research doesn't. The drift is invisible at edit time.
+
+The fix shape changes both the prose form (imperative + Iron Rule) **and** the layout (DRY canonical contract + per-site labels).
+
+### 2.2 Transition-type taxonomy (canonical map)
+
+The four overlapping transition points collapse to **two named checkpoint types** plus a **piggyback rule**:
+
+| Mechanism | Trigger condition | TaskCreate? |
+|---|---|---|
+| `pre-fanout` checkpoint | Before any parallel subagent dispatch (research specialists, plan per-task spec generators, parallel reviewers, parallel implementers, integration sub-stages). Replaces the previous "pre-large-subagent-dispatch" + "pre-review-loop" framings — both are fan-outs at runtime. | **Yes.** |
+| `pre-handoff` checkpoint | At end-of-skill, after artifact committed, before invoking the next skill in the route. Collapses the previous "terminal-state" + "cross-skill-transition" — they fired back-to-back today and the distinction was artificial. | **Yes.** |
+| **Piggyback rule** (not a separate checkpoint) | At every existing user-input pause anywhere in any QRSPI skill — review-loop pause-gate menus, verifier-uncertain surfacing, max-rounds-reached prompts, artifact-approval gates (Goals, Design, plan-final), replan-gate decisions, etc. The compact recommendation is surfaced alongside whatever question or content the SKILL is already showing the user. | **No** — the existing user-input prompt is itself the visibility surface. |
+
+**Key principle for the piggyback rule.** This rule does **not** introduce new pauses. It piggybacks on whatever pauses the SKILLs already create. If a review round loops clean and never pauses, no compact reminder fires. If a SKILL already pauses for any user-input reason, the compact recommendation rides along with the existing prompt.
+
+**Net change vs today's map.** Same coverage of context-bloat surfaces. The piggyback rule replaces the previous "post-review-round" idea — finer-grained (every existing pause, not just end-of-loop), no new pauses introduced, applies broadly across all SKILLs not just review. Two artificial pairs (terminal+cross-skill, pre-fanout+pre-review-loop) collapsed. One TaskCreate per skill run (at `pre-handoff`).
+
+### 2.3 Canonical contract — `using-qrspi/SKILL.md` § Compaction Checkpoints
+
+The Iron Rule contract lives in **one place** rather than duplicated across 12 SKILLs. New section in `skills/using-qrspi/SKILL.md` (the umbrella that every QRSPI skill invokes at start, so the contract is loaded once per run):
+
+```markdown
+## Compaction Checkpoints
+
+QRSPI skills mark transition points where main-chat context bloat degrades downstream quality. At every checkpoint and at every user-input pause, the orchestrator follows the Iron Rule below — regardless of perceived utilization, regardless of auto-mode.
+
+**Iron Rule.** Pause and recommend `/compact` to the user before continuing. The user can decline; do not skip the recommendation.
+
+**Auto-mode interaction.** Compaction recommendations are exempt from the auto-mode "minimize interruptions, prefer action" guidance. They exist precisely because mid-flight context bloat is the failure mode auto-mode runs into; honoring the recommendation is honoring the user's broader intent (deep, coherent execution), not interrupting it.
+
+**Two named checkpoints + a piggyback rule.**
+
+| Mechanism | Trigger | TaskCreate? |
+|---|---|---|
+| `pre-fanout` checkpoint | Before any parallel subagent dispatch. | **Yes.** |
+| `pre-handoff` checkpoint | At end-of-skill, after artifact committed, before invoking the next skill. | **Yes.** |
+| Piggyback rule | At every existing user-input pause (review pause-gate menus, verifier-uncertain prompts, max-rounds-reached prompts, artifact-approval gates, replan-gate decisions, any other "wait for user response" moment). Surface the compact recommendation **alongside** whatever the SKILL is already asking. Do **not** introduce new pauses. | No. |
+
+**TaskCreate at named checkpoints.** When the orchestrator reaches either named checkpoint (`pre-fanout` or `pre-handoff`), in addition to surfacing the imperative pause, call:
+
+`TaskCreate({ subject: "Recommend /compact ({checkpoint-type}) — {current-skill-name}", description: "{checkpoint-type}: {one-line stage-specific reason}. User decides whether to /compact." })`
+
+Mark the task `completed` once the user responds either way. The TaskCreate makes the recommendation visible in the user's task list. Piggyback pauses do **not** call TaskCreate — the existing user-input prompt at that site is itself the visibility surface, and a task entry would double-surface the same recommendation.
+
+**Per-checkpoint label format.** Every named checkpoint (`pre-fanout` / `pre-handoff`) in any SKILL.md uses this one-line shape:
+
+`**Compaction checkpoint: {type}.** {Stage-specific reason — one sentence.} See using-qrspi `## Compaction Checkpoints` for the iron-rule contract.`
+
+**Piggyback-pause format.** Existing user-input prompts gain a one-line addition (typically the last bullet or last sentence of the prompt):
+
+`Before responding, consider running `/compact` — context may be saturated. (You can decline; this is a reminder, not a gate.) See using-qrspi `## Compaction Checkpoints`.`
+
+The Iron Rule itself is NOT restated at per-site labels or piggyback-pause additions — the canonical contract above is the single source of truth. Per-site rationale stays specific to the moment (e.g., "Reviewer fan-out reads synthesis state; saturated context produces truncated findings"), the Iron Rule stays shared.
+```
+
+### 2.4 Per-site sweep
+
+For each SKILL.md compaction site (audited via `grep -rE 'Compaction recommended' skills/`), replace the existing blockquote with a one-line label per the canonical format:
+
+**Before (e.g., `skills/plan/SKILL.md:238`):**
+```
+> **IMPORTANT — Compaction recommended (pre-review-loop).** The merged `plan.md` plus `goals.md` + `research/summary.md` + `design.md` + `structure.md` are about to be handed to the review-round dispatch. Reviewer findings only land cleanly on a context that still holds the synthesis decisions; if utilization may exceed ~50%, run `/compact` now — before reviewers dispatch — so the upcoming cross-file consistency checks have headroom. **Iron Rule:** review-round dispatch is the highest-leverage compaction moment in Plan; do not skip this check.
+```
+
+**After:**
+```
+**Compaction checkpoint: pre-fanout.** Reviewer fan-out reads synthesis state; saturated context produces truncated findings on the cross-file consistency checks. See using-qrspi `## Compaction Checkpoints` for the iron-rule contract.
+```
+
+The "highest-leverage compaction moment in Plan" framing isn't lost — the canonical contract codifies the Iron Rule, and the stage-specific reason carries the site-specific weight.
+
+### 2.5 Sweep targets — two passes
+
+The implementation proceeds in two passes, since the sweep covers both named checkpoints (replacing existing blockquote sites) and piggyback additions (touching existing user-input prompts that don't currently mention compaction at all).
+
+**Pass 1 — named checkpoints.** Sites confirmed by `grep -rE 'Compaction recommended' skills/`. Each existing blockquote reclassifies to either `pre-fanout` or `pre-handoff`:
+
+| File | Existing label | New checkpoint type |
+|---|---|---|
+| `research/SKILL.md` | pre-review-loop, terminal-state, cross-skill | `pre-fanout`, `pre-handoff` (last two collapse) |
+| `design/SKILL.md` | pre-review-loop, others | `pre-fanout`, `pre-handoff` |
+| `structure/SKILL.md` | (audit) | `pre-fanout`, `pre-handoff` |
+| `plan/SKILL.md` | 6 sites: pre-large-subagent-dispatch (×2), pre-review-loop, others | Two `pre-fanout` (per-task fan-out + reviewer fan-out), one `pre-handoff` |
+| `parallelize/SKILL.md` | (audit) | typically just `pre-handoff` |
+| `implement/SKILL.md` | (audit) | `pre-fanout`, `pre-handoff` |
+| `integrate/SKILL.md` | (audit) | `pre-fanout`, `pre-handoff` |
+| `test/SKILL.md` | (audit) | `pre-handoff` |
+| `replan/SKILL.md` | (audit) | `pre-fanout`, `pre-handoff` |
+| `phasing/SKILL.md` | (audit) | `pre-handoff` |
+| `questions/SKILL.md` | (audit) | `pre-handoff` |
+| `using-qrspi/SKILL.md` | (umbrella; carries the canonical contract per §2.3) | N/A — host of the contract |
+
+**Pass 2 — piggyback additions at existing user-input pauses.** Sites identified by greping for existing user-input prompt patterns. Each gets the one-line piggyback-pause format from §2.3 added to the existing prompt body (typically as the last bullet or sentence). Audit candidates:
+
+- **Review-loop pause-gate menus** — wherever a SKILL surfaces the 3-option pause menu (apply / skip / loop back to upstream artifact) for `scope`/`intent` findings or `uncertain` verifier returns. Likely centralized in `using-qrspi/SKILL.md` `## Review Output Handling` and per-skill review-round sections.
+- **Artifact-approval gates** — Goals approval, Design approval, plan-final approval, structure approval, etc. Each SKILL has a "present to user, await approval" prompt at the end of synthesis (typically before the named `pre-handoff` checkpoint).
+- **Replan-gate decisions** — `replan/SKILL.md` surfaces phase-boundary decisions to the user.
+- **Max-rounds-reached prompts** — the review-loop ceiling triggers a user-input pause (likely in `using-qrspi/SKILL.md` or per-skill review-round logic).
+- **Any other ad-hoc user-input pause** discovered via grep — implementer surfaces unexpected sites as a question rather than guessing.
+
+**Implementer's audit step.** For each SKILL, two passes: (1) grep for `Compaction recommended` and reclassify the blockquote sites to named checkpoints; (2) grep for user-input pause patterns (e.g., "await approval", "ask the user", "surface to the user", pause-gate menu invocations) and add the piggyback-pause line. The exact pattern set is established during implementation — the spec's role is to define the rule, not enumerate every pause site.
+
+**Site count change.** Old: ~25 scattered sites with duplicated Iron Rule prose. New: ~22 one-line named-checkpoint labels + an estimated ~15–25 piggyback-pause additions + 1 canonical contract. Net: more total reminder surfaces (the piggyback rule expands coverage), but each surface is one line citing a single canonical contract — drift cost stays low.
+
+### 2.6 Test handling
+
+One bats file: `tests/unit/test-compaction-checkpoints.bats`
+
+```bash
+@test "no compaction prompt remains in legacy blockquote form" {
+  local offenders
+  offenders=$(grep -rE '^> \*\*IMPORTANT — Compaction recommended' skills/ || true)
+  if [ -n "$offenders" ]; then
+    echo "legacy blockquote compaction prompts:"
+    echo "$offenders"
+    return 1
+  fi
+}
+
+@test "no compaction prompt retains the may-exceed-50% conditional" {
+  local offenders
+  offenders=$(grep -rE 'if (context )?utilization may exceed' skills/ || true)
+  if [ -n "$offenders" ]; then
+    echo "compaction prompts retain conditional form:"
+    echo "$offenders"
+    return 1
+  fi
+}
+
+@test "every checkpoint label uses one of the two canonical types" {
+  local offenders
+  offenders=$(grep -rE '\*\*Compaction checkpoint:' skills/ \
+    | grep -vE '\*\*Compaction checkpoint: (pre-fanout|pre-handoff)\.\*\*' \
+    || true)
+  if [ -n "$offenders" ]; then
+    echo "checkpoint labels with non-canonical type:"
+    echo "$offenders"
+    return 1
+  fi
+}
+
+@test "every named checkpoint prescribes TaskCreate within 6 lines" {
+  local skills offenders
+  skills=$(grep -lE '\*\*Compaction checkpoint: (pre-fanout|pre-handoff)\.\*\*' skills/ -r || true)
+  for f in $skills; do
+    awk '/\*\*Compaction checkpoint: (pre-fanout|pre-handoff)\.\*\*/{flag=1; n=0; found=0} flag{n++; if (n>6) {flag=0; if (!found) print FILENAME": named-checkpoint site missing TaskCreate"; found=0} if (/TaskCreate/) found=1}' "$f" \
+      || return 1
+  done
+}
+
+@test "using-qrspi/SKILL.md carries the canonical Compaction Checkpoints section" {
+  grep -qE '^## Compaction Checkpoints' skills/using-qrspi/SKILL.md \
+    && grep -qE 'Iron Rule\..*Pause and recommend' skills/using-qrspi/SKILL.md
+}
+```
+
+Five assertions: legacy blockquote regression, legacy conditional regression, canonical-type enforcement on per-site labels, TaskCreate presence at `pre-handoff` sites, and canonical contract presence in `using-qrspi`. ~50 lines of bats; the layered checks defend the DRY structure (per-site labels can't drift to non-canonical types; canonical contract can't be silently deleted).
+
+### 2.7 Out of scope
+
+- **Alternative (a) — hook-enforced compaction.** Real engineering: needs context-utilization estimator + Claude Code hook integration + per-stage thresholds. Deferred to a future v0.x; revisit if the imperative + canonical-contract + piggyback-rule + TaskCreate-at-checkpoints fix proves insufficient.
+- **TaskCreate at piggyback pauses.** Piggyback sites stay prose-only — the existing user-input prompt at that site is itself the visibility surface, and a task entry would double-surface the same recommendation.
+- **Adding new pauses anywhere.** The piggyback rule is strict: it rides on existing pauses only. If a SKILL has no user-input pause at a particular moment, this PR does not introduce one.
+- **Adding a third checkpoint type** (e.g., "session-start" or "before-rejection-loop"). Two named types + the piggyback rule covers the load-bearing surface today.
+
+## 3. #40: LOC Ceiling = Source-Only Clarification
+
+### 3.1 Problem
+
+`skills/plan/SKILL.md` § Task Sizing prescribes a 200-LOC ceiling per task without specifying whether tests count. F-21 (`docs/qrspi/2026-04-26-prompt-improvements/findings.md`) observed Phase 1 tasks running 89–133 src LOC but 290–420 LOC counting tests + fixtures. Reviewers will rationalize the ambiguity inconsistently across tasks.
+
+### 3.2 Fix shape
+
+One-line addition to `skills/plan/SKILL.md` in the Task Sizing section:
+
+> **"LOC" = implementation source only** (counted across files in `Target files:` excluding `tests/`). Test code has no ceiling but should be roughly proportional to behaviors covered (rule of thumb: 1.5–2× impl LOC for full-behavior coverage). A task with 100 src LOC and 250 test LOC is fine; one with 250 src LOC needs a `sizing_exception` or split.
+
+This pairs with the existing "one observable behavior per task" framing — sizing is impl-defined, not test-defined.
+
+### 3.3 Test handling
+
+No test surface. `tests/unit/` carries no plan-reviewer task-sizing fixture today (verified by listing). Adding one is out of scope for a one-line clarification; the reviewer agent files (`agents/qrspi-plan-reviewer.md`, `agents/qrspi-plan-scope-reviewer.md`) read the sizing rule from `plan/SKILL.md` directly.
+
+If a future PR adds plan-reviewer fixtures, it should include a `150 src + 280 test` case classified as within-ceiling.
+
+## 4. Sequence
+
+Single PR. Three commits (group by atomicity unit):
+
+1. **`docs(plan): #40 LOC ceiling = src-only clarification`** — the smaller, more isolated change lands first; independent of #99.
+2. **`docs(using-qrspi): #99 add canonical Compaction Checkpoints contract`** — adds the new section in `using-qrspi/SKILL.md`. Lands before per-site sweep so sweep references resolve.
+3. **`docs(skills): #99 sweep per-site compaction labels + tests`** — replaces every blockquote site with a one-line canonical label per the §2.5 reclassification table; adds `tests/unit/test-compaction-checkpoints.bats` (which now passes because both the contract and the swept sites are in place).
+
+Test plan:
+- `bats tests/unit/test-compaction-checkpoints.bats` — all five assertions pass.
+- `bats tests/unit/` — full suite green.
+- Manual scan: open `using-qrspi/SKILL.md` and confirm the canonical contract reads cleanly; open Plan SKILL (highest site count) and confirm each former site is now a one-line label pointing at the canonical contract.
+
+## 5. Backwards compatibility
+
+Pure prose. No agent file, schema, or routing impact. Skills consuming the swept SKILLs (i.e., the orchestrator's runtime path through them) read the imperative prose the same way they read the blockquote prose — the agent's behavior change is the point of the fix, not a breaking change.
+
+## 6. Closes
+
+- Closes #99
+- Closes #40


### PR DESCRIPTION
## Summary

v0.5 spec round 3. Three specs covering five staging-status issues plus #125's follow-up cutover. Bundles chosen by surface-overlap (each bundle touches a single contiguous surface and would force re-touching the same files if split).

- **Spec A — `2026-05-05-99-40-prose-sweep-bundle-design.md`** — bundles #99 (compaction-prompt imperative sweep) + #40 (LOC ceiling = src-only). Introduces a canonical **Compaction Checkpoints** contract in `using-qrspi/SKILL.md` (Iron Rule, auto-mode exemption, named-checkpoint TaskCreate prescription, piggyback rule on existing user-input pauses). Per-site sweep replaces scattered blockquote prompts with one-line labels citing the canonical contract.
- **Spec B — `2026-05-05-118-115-interactive-skill-ux-bundle-design.md`** — bundles #118 (per-goal Design loop + auto-mode detection in Goals/Design) + #115 (per-researcher direct-write contract pin + summary-last authoring order). Three bats grep guards.
- **Spec C — `2026-05-05-125-deferred-reviewer-migration-design.md`** — atomic single-commit cutover for the 18 deferred reviewer agent files + dispatching SKILLs + reviewer-protocol bifurcation collapse + four #109 test extensions.

#112, #113, #114 deferred to the next spec round per the v0.5 staging plan.

## Open questions in Spec C

Surfaced in §12 of the #125 spec for explicit confirmation before implementation begins:

1. **§4.2 Expected-Reviewer Matrix tag names** — illustrative names (`plan-spec-claude`, `implement-gate-claude`, etc.) may not match what the dispatchers currently pass. Implementer reconciles by grep. Recommend keeping cutover migration-only, no rename.
2. **§9 in-flight-rebase guidance** — bats coverage or commit-message warning only? Recommend warning only.

## Test plan

- [x] `git status` clean on `qrspi-echo/v0.5-spec-round-3`
- [x] All three spec files committed in a single commit
- [ ] User reviews each spec doc and provides feedback before implementation begins
- [ ] On approval, each spec spawns its own implementation branch (or stays bundled per the eventual plan-writing decision)

## Closes (specs only — issues close when implementation lands)

Specs reference #99, #40, #118, #115, #125. Each issue stays open until its implementation PR closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
