### PR TITLE
v0.5 #118+#115: interactive-skill UX bundle

### DIFF
--- a/agents/qrspi-research-specialist.md
+++ b/agents/qrspi-research-specialist.md
@@ -42,7 +42,9 @@ Fix only the cited defects; do NOT extend scope beyond what the original questio
 
 Use the `Write` tool to save your report to `output_path`.
 
-The report MUST begin with this exact structure (the `## Summary` block at the top is mandatory — downstream collation and Design read it as the canonical at-a-glance summary; do not omit or rename its subsections):
+The report MUST begin with this exact structure (the `## Summary` block at the top is mandatory — downstream collation and Design read it as the canonical at-a-glance summary; do not omit or rename its subsections).
+
+**Authoring note:** investigate first, draft the body, write the summary block last — then place it at the top of the file. Do not generate the summary from intent.
 
 ```
 ---

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -9,6 +9,10 @@ description: Use when research/summary.md is approved and the QRSPI pipeline nee
 
 **Announce at start:** "I'm using the QRSPI Design skill to explore approaches and define the architecture."
 
+**If auto-mode is detected** (presence of `## Auto Mode Active` system-reminder in current context), surface to the user before the first interactive step: "This skill is collaborative — turn-by-turn dialogue produces better Design quality than autonomous execution. Recommend exiting auto-mode (`Esc` → off) for this phase. I'll proceed in either mode if you prefer."
+
+Do not force the user out of auto-mode; respect their choice. Surface the recommendation explicitly at start.
+
 ## Overview
 
 Translate research findings into an architecture through interactive discussion. Propose approaches with trade-offs, surface key architectural decisions with rationale, and include a test strategy at the design level. The discussion happens conversationally; a subagent synthesizes `design.md` per round.
@@ -44,7 +48,16 @@ Do NOT proceed to Structure without user approval of the design.
 
 ### Interactive Design Discussion
 
-1. Propose 2-3 design approaches with trade-offs, lead with recommendation
+**Phase 1 — per-goal:**
+
+1. **For each goal in `goals.md`, in order:**
+   1. Surface the relevant research findings from `research/summary.md` (and on-demand from `research/q*.md` if a decision depends on details).
+   2. Propose 2–3 candidate approaches; lead with recommendation; explain trade-offs.
+   3. Open Q&A — user asks back, you ask back, until the goal's design is settled.
+   4. Move to the next goal. Do **not** dump multiple goals' designs in one turn.
+
+**Phase 2 — cross-cutting (after all goals settled):**
+
 2. Include test strategy at the design level: what types of tests (unit, integration, E2E), what layers get tested, what frameworks. Assertion text and test file layout are deferred (see DEFERS).
 3. Include high-level Mermaid system diagram showing major components, relationships, and data flow
 4. Surface key architectural decisions with rationale (approach selection, technical trade-offs, data-flow boundaries). Phasing concerns — vertical slice authoring, phase boundaries, replan-gate criteria, PoC scoping — are owned by `qrspi:phasing` and not authored here.
@@ -233,6 +246,7 @@ Call `TaskCreate({ subject: "Recommend /compact (pre-handoff) — design", descr
 - Approach rationale missing — chosen approach stated but trade-offs not explained
 - "We might need X later" as justification for including X now
 - Design embeds DEFERS-list content (full DDL, full function signatures, full assertion text, line-by-line logic) — this content is owned downstream by Plan / Implement
+- Batch-presenting designs for multiple goals in one turn — pace the discussion goal-by-goal.
 
 ## Common Rationalizations — STOP
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -9,7 +9,7 @@ description: Use when research/summary.md is approved and the QRSPI pipeline nee
 
 **Announce at start:** "I'm using the QRSPI Design skill to explore approaches and define the architecture."
 
-**If auto-mode is detected** (presence of `## Auto Mode Active` system-reminder in current context), surface to the user before the first interactive step: "This skill is collaborative — turn-by-turn dialogue produces better Design quality than autonomous execution. Recommend exiting auto-mode (`Esc` → off) for this phase. I'll proceed in either mode if you prefer."
+**If auto-mode is detected** (presence of `## Auto Mode Active` system-reminder in current context), surface to the user before the first interactive step: "This skill is collaborative — turn-by-turn dialogue produces better Design quality than autonomous execution. Recommend exiting auto-mode (`Shift+Tab` to cycle modes) for this phase. I'll proceed in either mode if you prefer."
 
 Do not force the user out of auto-mode; respect their choice. Surface the recommendation explicitly at start.
 

--- a/skills/goals/SKILL.md
+++ b/skills/goals/SKILL.md
@@ -9,7 +9,7 @@ description: Use when starting a new QRSPI pipeline run — captures user intent
 
 **Announce at start:** "I'm using the QRSPI Goals skill to capture what you want to build."
 
-**If auto-mode is detected** (presence of `## Auto Mode Active` system-reminder in current context), surface to the user before the first interactive step: "This skill is collaborative — turn-by-turn dialogue produces better Goals quality than autonomous execution. Recommend exiting auto-mode (`Esc` → off) for this phase. I'll proceed in either mode if you prefer."
+**If auto-mode is detected** (presence of `## Auto Mode Active` system-reminder in current context), surface to the user before the first interactive step: "This skill is collaborative — turn-by-turn dialogue produces better Goals quality than autonomous execution. Recommend exiting auto-mode (`Shift+Tab` to cycle modes) for this phase. I'll proceed in either mode if you prefer."
 
 Do not force the user out of auto-mode; respect their choice. Surface the recommendation explicitly at start.
 

--- a/skills/goals/SKILL.md
+++ b/skills/goals/SKILL.md
@@ -9,6 +9,10 @@ description: Use when starting a new QRSPI pipeline run — captures user intent
 
 **Announce at start:** "I'm using the QRSPI Goals skill to capture what you want to build."
 
+**If auto-mode is detected** (presence of `## Auto Mode Active` system-reminder in current context), surface to the user before the first interactive step: "This skill is collaborative — turn-by-turn dialogue produces better Goals quality than autonomous execution. Recommend exiting auto-mode (`Esc` → off) for this phase. I'll proceed in either mode if you prefer."
+
+Do not force the user out of auto-mode; respect their choice. Surface the recommendation explicitly at start.
+
 ## Overview
 
 Capture what the user wants — purpose, environmental constraints, and the per-goal problem frames that downstream skills will work against. Runs as an interactive conversation in the main session, then launches a subagent to synthesize the artifact.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -64,6 +64,10 @@ Dispatch parameters (per specialist):
 - `question_ids`: comma-separated numeric IDs the report should cover (e.g., `3` or `3,7`)
 - `defect_summary` (re-dispatch via Rejection path 2 only): orchestrator-authored sanitized defect summary; goal-bearing/intent-bearing language stripped
 
+**Direct-write contract (unambiguous default).** Per-researcher subagents write their `q*.md` report directly to `output_path` via the `Write` tool. They do **not** return report content as text. Text-return is not used anywhere in the research pipeline — the collation subagent also direct-writes (to the `research/_collated.md` staging filename, which the orchestrator then renames to `research/summary.md`). The staging-filename pattern exists precisely to avoid text-return through main chat. If the orchestrator ever omits `output_path` from a per-researcher dispatch, that is a dispatch defect — fix the orchestrator, do not fall back to text-return.
+
+**Summary-last authoring order.** The per-question report template places the structured summary block (TL;DR / key findings / surprises / caveats) at the **top** of the file — that is the consumer-facing reading order. Authoring order is the inverse: investigate first, draft the full report body, then author the summary block **last**, then place it at the top of the file. Do not generate the summary from intent before the body is complete.
+
 **Research-isolation invariant** — the specialist dispatch carries NO `companion_goals`, NO other-question content, and NO `feedback/research-round-*.md` files. This is structurally enforced — the agent body refuses goals.md / cross-question content if it ever appears in the dispatch prompt. Research isolation prevents confirmation bias.
 
 ### Collation Subagent (verbatim extraction, not synthesis)

--- a/tests/unit/test-interactive-skill-prompts.bats
+++ b/tests/unit/test-interactive-skill-prompts.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+#
+# #118 / #115 Interactive-skill UX bundle — defends the prose anchors in the
+# collaborative-skill preambles (auto-mode detection in goals + design) and
+# the per-researcher dispatch contract pins (direct-write + summary-last
+# authoring order in research). Cheap grep guards; catch accidental deletion
+# during future SKILL.md edits.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  export REPO_ROOT
+}
+
+@test "goals/SKILL.md carries the auto-mode detection paragraph" {
+  grep -F "Auto Mode Active" "$REPO_ROOT/skills/goals/SKILL.md"
+}
+
+@test "design/SKILL.md carries the auto-mode detection paragraph" {
+  grep -F "Auto Mode Active" "$REPO_ROOT/skills/design/SKILL.md"
+}
+
+@test "research/SKILL.md carries the direct-write and summary-last contract pins" {
+  grep -F "Direct-write contract" "$REPO_ROOT/skills/research/SKILL.md"
+  grep -F "Summary-last authoring order" "$REPO_ROOT/skills/research/SKILL.md"
+}


### PR DESCRIPTION
## Summary

v0.5 Spec B (interactive-skill UX bundle) — bundles two issues that share the same shape (prose refinements at specific dispatch/preamble sites in interactive SKILLs):

- **#115** Per-researcher dispatch refinements
- **#118** Per-goal Design loop + auto-mode detection

Spec at `docs/superpowers/specs/2026-05-05-118-115-interactive-skill-ux-bundle-design.md` (landed in spec-round-3 PR #129).

## Commits

1. **`367d2a6`** `docs(research): #115 per-researcher dispatch prompt refinements` — adds two paragraphs to `skills/research/SKILL.md` § Per-Researcher Subagent dispatch parameters area:
   - **Direct-write contract (unambiguous default)** — pins direct-write to `output_path` as the contract; text-return is not a fallback; omitted `output_path` is a dispatch defect to fix at source.
   - **Summary-last authoring order** — investigate first, draft body, write summary block last (then placed at top per consumer-facing layout). Prevents intent-generated summaries.
   - One-line authoring-note reminder near the report-template scaffold in `agents/qrspi-research-specialist.md`.

2. **`156cc12`** `docs(goals,design): #118 per-goal Design + auto-mode detection`:
   - **Per-goal Design loop** — restructures `skills/design/SKILL.md` § Interactive Design Discussion into a two-phase shape: Phase 1 = per-goal loop (research → 2-3 approaches → Q&A → settled → next goal, no batch dumps); Phase 2 = cross-cutting work (test strategy, mermaid, key decisions, amendment handling) after all goals settle.
   - **Auto-mode detection** in both collaborative-skill preambles (`skills/goals/SKILL.md` and `skills/design/SKILL.md`). On detection of `## Auto Mode Active` system-reminder, the skill surfaces a one-time recommendation to exit auto-mode for the collaborative phase, but proceeds either way. Soft surface, not a gate.
   - **Red Flags entry** in `design/SKILL.md` against batch-presenting designs for multiple goals in one turn.
   - **New bats guard** `tests/unit/test-interactive-skill-prompts.bats` — 3 assertions covering both commits' literals (auto-mode in goals + design, direct-write + summary-last in research).

## Scope

Pure prose + one new test file. No agent dispatch params, schema, or routing changes.

## Test plan

- [x] `bats tests/unit/test-interactive-skill-prompts.bats` — 3/3 pass
- [x] `bats tests/unit/` — no regressions from this PR (16 pre-existing fails on parent commit `89cf343` are unrelated to these edits, verified via stash + baseline run)
- [x] Manual scan of restructured `design/SKILL.md` § Interactive Design Discussion confirms phase boundaries read naturally

## Closes

- Closes #118
- Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
