### PR TITLE
v0.5 spec round 4: #113+#41+#90, #114, #112 specs

### DIFF
--- a/docs/superpowers/specs/2026-05-05-112-scope-tag-derivation-design.md
+++ b/docs/superpowers/specs/2026-05-05-112-scope-tag-derivation-design.md
@@ -1,0 +1,257 @@
+# #112: Convergence-Driven Diff Narrowing via `scope_tag` Subagent
+
+**Status:** Design
+**Issue:** [#112](https://github.com/dfrysinger/qrspi-plus/issues/112)
+**Source plan:** Combined Opts #2 + #7 of `qrspi-review-optimization-plan.md`
+**Milestone:** v0.5
+**Date:** 2026-05-05
+
+## 1. Problem
+
+Long review loops on a single artifact pay full-token cost every round. A real example: the v0.4 bundle's `goals.md` review held three Claude+Codex reviewers reading the entire 1838-line bundle every round even when round-N-1 and round-N findings had already converged on the same surface (`## Approach`). Estimated waste: ~$8–10/round once findings have stabilized.
+
+Two independent token-savings mechanisms in the optimization plan address this; both are bundled here because they compose naturally and share infrastructure.
+
+## 2. Design
+
+### 2.1 Two mechanisms, one PR
+
+**Mechanism A — orchestrator-generated diff file:** the orchestrator runs `git diff <ref> -- <artifact_path> > reviews/{step}/round-NN.diff` once per round (Bash redirect: diff content never enters orchestrator context). Both reviewers (Claude + Codex) Read the same file. Single git op per round, byte-identical reviewer input, no main-chat pollution from the diff.
+
+**Mechanism B — `scope_tag` subagent + convergence detection:** a dedicated `qrspi-scope-tagger` subagent reads each round's kept findings post-verifier-fan-in and emits a `scope-set` file. Main chat compares the current round's scope-set to the prior round's; on convergence (rule per §2.4) it narrows the next round's diff and injects a focus hint into reviewer prompts.
+
+A is a useful mechanism on its own (purely how reviewers receive the diff). B is what creates the convergence-driven savings. They land in the same PR because B's narrowing is implemented by changing A's `<ref>` selection at dispatch time.
+
+### 2.2 Why a dedicated subagent (not orchestrator-derived)
+
+The optimization plan's original framing said "orchestrator-derived" because the work piggy-backs on the apply-fix turn that's already happening — main chat already reads findings and the artifact at that point.
+
+In practice, this conversation chose Option C — a dedicated `qrspi-scope-tagger` Haiku subagent — for three reasons:
+
+1. **Pattern consistency.** The verifier subagent introduced in #109 (a small Haiku model that scores each finding 0–100 and returns a structured sidecar) is the established precedent for "small structured task post-fan-in." Tagging is the same shape.
+2. **Main-chat context preservation.** Main chat at apply-fix time is already heavy with synthesis state. Offloading the per-finding tag derivation to a subagent that returns only the structured tag list — never the finding bodies — keeps main chat's context focused on the apply-and-route work.
+3. **Future-proofing.** If tag derivation gains nuance (e.g. cross-finding similarity scoring, semantic clustering within an H2 section), the subagent is the natural place for it. Orchestrator-derived would have to either accumulate the logic in main chat or get refactored to a subagent later anyway.
+
+### 2.3 What the tagger derives
+
+For each kept finding (kept = after the verifier filter from #109), the tagger derives one `scope_tag` string:
+
+- **Multi-file artifacts** (integrate, implement-per-task, plan + tasks/, research/): `scope_tag = file path` from the finding's `referenced_files`. Already canonical in the existing schema; zero derivation work.
+- **Single-file artifacts** (goals.md, design.md, questions.md, phasing.md, structure.md, parallelization.md, replan.md): `scope_tag = enclosing H2 heading text` (e.g. `"## Approach"`). The tagger reads the artifact body, parses heading structure, and maps each finding's line range to its enclosing H2. Granularity decision: **start at H2** (coarser, more conservative narrowing). H3 reconsidered if narrowing fires too rarely in practice.
+
+**Reviewer-side prerequisite:** findings must include line-range citation in `referenced_files` (e.g. `path/to/file.md:120-145`). Most reviewers do already; this spec adds an enforcement note in the reviewer-protocol skill (one line — no schema field added).
+
+### 2.4 Convergence rule (the narrowing decision)
+
+After every round N ≥ 2, the orchestrator compares the current round's `scope_set(N)` to `scope_set(N-1)`. Decision:
+
+| Relation between sets | Decision for round N+1 |
+|---|---|
+| `scope_set(N) == scope_set(N-1)` | **Narrow** to that set |
+| `scope_set(N) ⊂ scope_set(N-1)` (proper subset) | **Narrow** to the broader set (= `scope_set(N-1)`) — safety margin against the dropped tags reappearing |
+| `scope_set(N) ⊃ scope_set(N-1)` (proper superset; new tags appeared) | **Broaden** — back to full-scope |
+| Partial overlap (neither subset relation holds) | **Broaden** — back to full-scope |
+| Disjoint | **Broaden** — back to full-scope |
+
+Notes on this rule:
+- **Narrowing is incremental, not all-or-nothing.** A single tag in the set is not required; a 3-element set narrowing to a 2-element subset still narrows. Over successive rounds the diff size shrinks as findings stabilize.
+- **Subset case uses the broader of the two sets** as the safety margin. If round N-1 had findings on `{Approach, Tradeoffs, Testing}` and round N had findings on `{Approach, Tradeoffs}`, round N+1 narrows to `{Approach, Tradeoffs, Testing}` — not just `{Approach, Tradeoffs}` — because we're not yet confident `Testing` is fully resolved.
+- **Earliest narrowing = round 3** (needs scope-sets from rounds 1 and 2 to compare).
+- **Auto-broaden** the moment a new tag appears (superset or partial overlap). The plan's "cluster breaks → return to full-scope" rule applies in any non-subset/non-equal case.
+
+### 2.5 What the orchestrator does with a narrowed decision
+
+When the rule says "narrow to set `S`":
+1. Diff ref selection: `<ref> = HEAD~1` (this round's delta only, vs full-base).
+2. Scope hint: `scope_hint = S` (a list of tags) is injected into reviewer dispatch prompts as advisory focus — not a hard restriction. Reviewers can still surface findings outside the hint if they notice them; that's exactly what triggers the auto-broaden on the next round.
+3. The diff file (Mechanism A) is generated against `<ref>=HEAD~1`, so its byte size shrinks naturally with the narrower ref.
+
+When the rule says "broaden":
+1. `<ref> = base-branch` (full artifact treated as new).
+2. No scope hint injected.
+
+### 2.6 Per-step applicability
+
+Convergence narrowing is enabled per-step. From the optimization plan, with no changes:
+
+| Step | Apply convergence narrowing? | Reason |
+|---|---|---|
+| Goals / Questions / Research / Design / Phasing / Structure / Plan / Parallelize / Replan | **Yes** | Single-file (or small multi-file) artifacts; long review loops; primary target |
+| Implement (per-task review) | For consistency only | Tasks usually narrow already; modest savings |
+| **Integrate** | **Yes — high payoff** | Cross-task review touches many files; clustering into "auth-related changes" is exactly the right call |
+| Test | **No** | Test reviewers analyze test quality / coverage gaps, not "where in the diff" — pattern doesn't fit |
+
+## 3. Architecture
+
+### 3.1 Where the tagger fits in the apply-fix flow
+
+Current Apply-fix (per `using-qrspi/SKILL.md` § Apply-fix):
+
+```
+1. Enumerate finding-files in round-NN/
+2. Compute round NN findings list
+3. Verifier-enabled gate (config.md)
+4. Parallel verifier dispatch (one Haiku per finding-file)
+5. Main chat assembles round-NN-verified.md (kept vs dropped partition)
+6. Apply scope/intent escalation rules
+7. Edit auto-apply (style/clarity/correctness, score ≥80) OR pause-gate (scope/intent or low-score override)
+```
+
+#112 adds **one new substep** between 5 and 6:
+
+```
+5.5  Scope-tagger dispatch (one Haiku subagent reads kept findings, emits round-NN-scope-set.txt)
+```
+
+And a separate orchestrator step **after step 7** (after fixes are committed, before round NN+1 dispatch):
+
+```
+7.5  Convergence comparison + diff-file generation for round NN+1
+     - Compare scope_set(NN) to scope_set(NN-1) per §2.4 rule
+     - Choose <ref> per §2.5
+     - Run `git diff <ref> -- <artifact_path> > reviews/{step}/round-(NN+1).diff`
+     - Pass <diff_file_path>, <scope_hint> (if any) to round-(NN+1) reviewer dispatch
+```
+
+### 3.2 New artifact: `reviews/{step}/round-NN-scope-set.txt`
+
+Tiny per-round file. Schema:
+
+```
+# scope-set for round 7
+# generated_by: qrspi-scope-tagger
+# total_findings_kept: 5
+## Approach
+## Tradeoffs
+## Testing
+```
+
+Plain text, one tag per line, comments at top for diagnostics. Single-file artifact tags are H2 heading text (`## Approach`); multi-file artifact tags are file paths (`skills/research/SKILL.md`). The orchestrator reads only the tag lines (skips comments) when computing `scope_set`.
+
+Choosing plain text over JSON: the orchestrator's set comparison is simple line-set equality; plain text gives a forensic-readable diff in `git log -p` between rounds (the user can see at a glance how the scope is evolving).
+
+### 3.3 Tagger contract
+
+`agents/qrspi-scope-tagger.md` — new file. Haiku, structured-output discipline.
+
+**Inputs (via wrapped Task prompt):**
+- `round_subdir`: absolute path to the round's directory
+- `kept_findings`: list of finding-file paths after verifier filtering
+- `artifact_path`: the single-file artifact (for H2 derivation), or null for multi-file artifacts
+- `artifact_body`: artifact body wrapped between `<<<UNTRUSTED-ARTIFACT-START>>>` / `<<<UNTRUSTED-ARTIFACT-END>>>` markers (for H2 derivation), or null for multi-file artifacts
+
+**Behavior:**
+1. Read each kept finding (one at a time; small files).
+2. Extract the line-range citation from `referenced_files`.
+3. **Multi-file case:** emit `scope_tag = file path` from `referenced_files`.
+4. **Single-file case:** parse the artifact body for H2 headings (lines matching `^## `), build a line-range index, find the H2 whose range contains the finding's line-range, emit that heading text as `scope_tag`.
+5. Deduplicate the tag list and emit `round-NN-scope-set.txt` per §3.2.
+
+**Output discipline:**
+- Tagger writes only `round-NN-scope-set.txt`. No mutation of finding-files. No re-classification of `change_type` or `severity`.
+- If a finding's `referenced_files` lacks line-range citation, the tagger emits a warning comment in the scope-set file (`# warning: F03 had no line-range; tagged as full-artifact`) and tags it with the artifact's whole-file marker (e.g. `<full>`). One whole-file tag in the set means convergence detection sees the round as "covers everything" — narrowing won't fire that round, which is the conservative behavior.
+
+### 3.4 Tagger-disabled gate
+
+Mirroring the verifier's `verifier_enabled` gate, add `scope_tagger_enabled: <bool>` to `config.md`. Default `true` for fresh runs. When `false`:
+- Step 5.5 is skipped (no tagger dispatch, no scope-set file emitted).
+- Step 7.5's convergence comparison treats every round as full-scope (no narrowing fires).
+- Reviewer dispatch falls through to today's full-base-diff behavior.
+
+Same backfill semantics as `verifier_enabled` — missing field on resumed pre-#112 runs treated as `true` with a one-line stderr warning.
+
+### 3.5 Reviewer dispatch changes
+
+Each reviewer Task prompt today includes the artifact body wrapped in untrusted-data markers. Two changes:
+
+1. **Add `<diff_file_path>` parameter.** The diff file (Mechanism A) lives at `reviews/{step}/round-NN.diff`. Reviewer reads it via the Read tool; the diff content does not appear in the dispatch prompt.
+2. **Add optional `<scope_hint>` parameter.** When present (narrowing fired), reviewer prompts include a one-line advisory: "This round's diff is narrowed to: {scope_hint}. Focus your review on this surface but flag anything significant outside it."
+
+The reviewer-protocol skill needs an updated dispatch contract section documenting both parameters. Existing reviewer agent files need updates to document the diff-file Read pattern.
+
+## 4. Files touched
+
+### New
+- `agents/qrspi-scope-tagger.md` — new agent file (~150 LOC; smaller than the verifier because the work is more structured)
+- `tests/unit/test-scope-tagger-dispatch.bats` — tagger output schema regression
+- `tests/unit/test-convergence-narrowing.bats` — orchestrator convergence-rule unit tests (table-driven over the §2.4 cases)
+- `tests/unit/test-diff-file-emission.bats` — Mechanism A regression (orchestrator generates diff file; reviewer dispatch carries the path)
+
+### Modified — orchestration
+- `skills/using-qrspi/SKILL.md`:
+  - § Apply-fix: insert step 5.5 (tagger dispatch)
+  - § Apply-fix: insert step 7.5 (convergence comparison + diff-file generation for next round)
+  - § Configuration: document `scope_tagger_enabled`
+  - § Artifact tree: add `round-NN-scope-set.txt` and `round-NN.diff` to the per-round directory listing
+- `skills/reviewer-protocol/SKILL.md`:
+  - One-line note: `scope_tag` is derived by `qrspi-scope-tagger` post-fan-in, not reviewer-emitted
+  - Reviewer dispatch contract: document `<diff_file_path>` and optional `<scope_hint>` parameters
+  - Reviewer-boilerplate: line-range citation in `referenced_files` is required (most reviewers do this already; the note formalizes the requirement)
+
+### Modified — per-skill review-round wiring (per the §2.6 applicability table)
+- `skills/{goals,questions,research,design,phasing,structure,plan,parallelize,replan}/SKILL.md` — Yes, primary target
+- `skills/integrate/SKILL.md` — Yes, high payoff
+- `skills/implement/SKILL.md` — for consistency
+- `skills/test/SKILL.md` — explicitly opts out (one-line note)
+
+Each per-skill update is mechanical: replace "reviewer reads the artifact and produces findings" framing with "orchestrator generates `round-NN.diff` via Bash redirect; reviewer dispatch carries the diff-file path."
+
+### Modified — agent files
+- `agents/qrspi-{quality,scope}-reviewer.md` (Claude reviewers per skill) — document the new diff-file Read pattern + optional scope_hint focus
+- Codex reviewer dispatch skills — document the same two parameters
+
+### Tests touched
+- Existing apply-fix bats (`tests/unit/test-using-qrspi.bats`, `tests/acceptance/test-pipeline-ordering.bats`) — extend to cover the new tagger step + convergence path
+
+## 5. Sequence
+
+This is the heaviest of the v0.5 round-4 specs. Strongly consider splitting implementation into two PRs:
+
+- **PR-1 (Mechanism A read-only): orchestrator-generated diff file.** Add the diff file generation, route reviewer dispatch through it, but keep round NN+1 always running with `<ref>=base-branch`. No tagger, no convergence logic, no narrowing. Independently valuable: takes the diff out of main chat. Safe to land first.
+- **PR-2 (Mechanism B): tagger + convergence narrowing.** Add the tagger agent file, the scope-set file emission, the convergence rule, the dispatch-time `<ref>` selection logic, and the optional `scope_hint` advisory. Builds on PR-1's diff-file infrastructure.
+
+If implementation goes single-PR, **commit ordering**:
+1. `feat(scripts): #112 orchestrator generates round-NN.diff via Bash redirect`
+2. `feat(skills): #112 reviewer dispatch reads diff file (Mechanism A wiring)`
+3. `feat(agents): #112 add qrspi-scope-tagger agent file`
+4. `feat(skills): #112 wire tagger dispatch + scope-set file emission`
+5. `feat(config): #112 scope_tagger_enabled gate + backfill`
+6. `feat(skills): #112 convergence rule + ref selection + scope_hint advisory`
+7. `test(unit): #112 tagger + convergence + diff-file regression`
+
+Test plan:
+- New bats files pass (tagger schema, convergence rule table-driven, diff-file emission).
+- Existing apply-fix bats green.
+- Manual: drive a long review loop on a single-file artifact (e.g. design.md) with stable findings on `## Approach`. Confirm:
+  - Round 1 + 2 fire full-scope; scope-set files emitted correctly.
+  - Round 3 narrows (`<ref>=HEAD~1`, scope_hint = `## Approach`).
+  - If round 3 surfaces a finding on `## Tradeoffs`, round 4 broadens back.
+- Manual: same loop with `scope_tagger_enabled: false` — confirm no tagger dispatch, no narrowing, behavior matches today.
+
+## 6. Reviewer Suite
+
+Heavily runtime-touching: new agent file, new orchestration step, new dispatch parameters, new convergence logic. Full reviewer suite required: spec, code-quality, security, silent-failure, goal-traceability, test-coverage, type-design (the scope-set comparison rules and tagger output schema warrant type-design review). Implement-stage gate enabled. The qrspi-plus prose-handling preference does **not** apply.
+
+## 7. Out of scope
+
+- **Reviewer-set `scope_tag`.** Explicitly rejected per the v0.5 sequencing constraint (normalization drift + perspective leak). The tag is orchestrator-side, computed by the tagger subagent.
+- **Section-level diff filtering.** Mechanism A narrows by ref (`HEAD~1` vs base-branch), not by file/section. Section-level diffing isn't a native git operation; the `scope_hint` in reviewer prompts handles within-file focus advisorily. If hint-based focus proves insufficient, file/section filtering is a future spec.
+- **Cross-round cluster persistence beyond `(N-1, N)` pairwise comparison.** No attempt at "this scope reappeared after broadening for two rounds, narrow again." Pairwise is what the rule covers; multi-round history is a future spec if pairwise undershoots.
+- **Tag normalization registry.** Tags are descriptive strings; no canonical-form enforcement, no validator. The deterministic-orchestrator-derivation property in §2.2 is what prevents normalization drift.
+- **Session-state caching of scope-sets across `/compact`.** The scope-set files live on disk per round; resume after compact reads them from disk. No in-memory cache.
+
+## 8. Backwards Compatibility
+
+- **Pre-#112 runs.** Resume into a pre-existing run directory: `scope_tagger_enabled` backfill (per §3.4) treats missing field as `true` with one-line warning; first round after upgrade runs the tagger. Prior rounds have no scope-set file on disk, so convergence comparison treats round NN-1 as a "missing prior" and stays full-scope until two consecutive rounds have scope-sets — earliest narrowing in a resumed run is round NN+2, not NN+1.
+- **`scope_tagger_enabled: false`** is a clean opt-out; flow is identical to today.
+- **Mechanism A diff files** are scratch artifacts; they're committed alongside the round's other review files but no consumer outside that round reads them.
+
+## 9. Open / deferred decisions (from the optimization plan)
+
+- **`scope_tag` granularity for single-file artifacts:** start at H2 per §2.3. Reconsider H3 if narrowing fires too rarely in practice.
+- **Backward-loop edits:** when an earlier-artifact loop-back rewrites a downstream artifact, the orchestrator must reset `<ref>` to base-branch on the next round (the artifact has been rewritten; prior round's diff anchor is stale). Logic addition at loop-back reset points; flagged here so the implementer plans for it.
+- **Round-1 default ref:** base-branch (artifact treated as fully new). Confirmed by the optimization plan.
+
+## 10. Closes
+
+- Closes #112

--- a/docs/superpowers/specs/2026-05-05-113-41-90-prose-bundle-design.md
+++ b/docs/superpowers/specs/2026-05-05-113-41-90-prose-bundle-design.md
@@ -1,0 +1,224 @@
+# Prose Bundle: #113 fixes→dispositions rename + #41 Group→Wave collapse + #90 nested-task naming
+
+**Status:** Design
+**Issues:** [#113](https://github.com/dfrysinger/qrspi-plus/issues/113), [#41](https://github.com/dfrysinger/qrspi-plus/issues/41), [#90](https://github.com/dfrysinger/qrspi-plus/issues/90)
+**Milestone:** v0.5
+**Date:** 2026-05-05
+
+## 1. Bundle Rationale
+
+Three cross-cutting prose changes that share both a risk profile and a test surface:
+
+- **#113** — pure rename (`round-NN-fixes.md` → `round-NN-dispositions.md`)
+- **#41** — vocabulary collapse (Parallel Group → Wave)
+- **#90** — naming convention for sub-tasks under each Wave (`  └─ task-NN ...`)
+
+All three are SKILL.md-prose edits with bats grep-based tests; none touch schema, routing, or runtime control flow. Per the qrspi-plus prose-handling preference: skip full reviewer suite, decide test handling per change, no TDD ceremony for non-runtime edits.
+
+Bundling avoids three near-identical "audit and edit prose" PRs back-to-back. Each section below is independently implementable; the sequencing in §5 keeps grep-guards and rename targets from stepping on each other.
+
+## 2. #113: Rename `round-NN-fixes.md` → `round-NN-dispositions.md`
+
+### 2.1 Problem
+
+The per-round main-chat-authored summary file is named `round-NN-fixes.md` but its content can legitimately include `disposition: no-action` entries (the fix-round agreed with the user that the finding is intended behavior, or that the finding is wrong). The current name implies every entry produced a code change, which is false.
+
+### 2.2 Fix shape
+
+Rename the artifact across every reference site. No semantic or content change to the file itself — only its filename and the prose pointing at it.
+
+Confirmed reference sites (`grep -rE "round-[0-9N]+-fixes|fixes\.md"` across `skills/`, `agents/`, `tests/`):
+
+| File | Lines | Surface |
+|---|---|---|
+| `skills/using-qrspi/SKILL.md` | 171, 191, 493, 656, 660, 709 | Artifact tree (`round-01-fixes.md` example + `round-NN-fixes.md` template), Per-Round Commit prose, Round-NN Fixes Document section header + body, Per-Round Commit Coverage block |
+| `tests/unit/test-verifier-dispatch-contract.bats` | 22 | grep-guard regex `Write.*round-NN-fixes\.md` |
+| `tests/unit/test-no-legacy-disk-write-references.bats` | 12 | comment listing legitimate non-reviewer artifacts |
+
+The `using-qrspi` surface is the canonical one; per-skill SKILLs reference the contract through `using-qrspi` rather than re-naming the file directly. Confirmed by inverse grep: no `skills/{plan,implement,integrate,...}/SKILL.md` references the literal filename. (One implicit reference: the per-round commit description in each per-skill review-round section says "fixes" as a noun — those stay; the rename is filename-only, not concept-renaming.)
+
+### 2.3 Test handling
+
+- **Update** `tests/unit/test-verifier-dispatch-contract.bats:22` regex from `Write.*round-NN-fixes\.md` → `Write.*round-NN-dispositions\.md`. Existing assertion semantics preserved.
+- **Update** the comment in `tests/unit/test-no-legacy-disk-write-references.bats:12` to list `round-NN-dispositions.md` instead of `round-NN-fixes.md` — the test itself doesn't enforce that name, the comment is documentation.
+- **Add** a new bats assertion in `test-no-legacy-disk-write-references.bats` (or a sibling file) that fails on any remaining `round-NN-fixes\.md` literal in `skills/`, `agents/`, or `docs/superpowers/` — guards against partial rename:
+
+  ```bash
+  @test "no skill or agent file references the legacy fixes filename" {
+    local offenders
+    offenders=$(grep -rnE 'round-[0-9N]+-fixes\.md' skills/ agents/ 2>/dev/null || true)
+    if [ -n "$offenders" ]; then
+      echo "legacy round-NN-fixes.md references remain:"
+      echo "$offenders"
+      return 1
+    fi
+  }
+  ```
+
+  Five lines of bats; same shape as the existing legacy-pattern guards introduced for #125.
+
+### 2.4 Out of scope
+
+- **Renaming the *concept*** ("fix-round" → "disposition-round"). The orchestrator step that produces this file is still naturally called "fix-apply" — most rounds do produce fixes; "disposition" is the more accurate name for *the file*, not for the orchestrator phase. Keep "fix-round" prose intact.
+- **Migrating existing on-disk artifacts** in `reviews/{step}/round-NN-fixes.md` from prior runs. The rename is forward-only; historical artifacts keep their old name. (Untracked `reviews/` dirs are gitignored anyway.)
+
+## 3. #41: Collapse Parallel Group into Wave (Phase / Slice / Task / Wave)
+
+### 3.1 Problem
+
+QRSPI today maintains five levels of decomposition for one body of work — Phase, Vertical Slice, Task, Parallel Group, Dispatch Wave. The Parallelize SKILL spends a ~200-word disambiguation paragraph (line 72 of `skills/parallelize/SKILL.md`) explaining why Group ≠ Wave despite the two being numbered 1:1 in every realistic phase. F-22 evidence: the 9-task v0.4-bundle test produced exactly one parallel group per wave; the theoretical "multiple disjoint groups in one wave" case never materialized. Cognitive load + explicit user complaint.
+
+### 3.2 Fix shape — semantic decision
+
+**Wave is the surviving name.** "Parallel Group" deletes from the vocabulary. Wave inherits *all* of Group's invariants:
+
+- Wave membership = tasks share a base AND have no file overlap (was Group's defining invariant)
+- Wave numbering does not imply dispatch ordering (was Group's caveat; Wave's own caveat is dropped — concurrency is a runtime property, not a vocabulary concept)
+- Wave bases use the same symbolic vocabulary (`feature branch tip`, `task-NN tip`, `stage-after-W{N}`, `task-00 tip`)
+
+**Concurrency derives from the Wave dependency graph at runtime, not from "Waves can contain multiple Groups."** Implement's runtime rule becomes: "Each tick, dispatch every Wave whose dependencies are satisfied and whose tasks are not yet dispatched." A "wave with two groups in it" under the old vocab becomes "two Waves with no inter-Wave dependency, dispatched concurrently" under the new vocab.
+
+**Slice stays as a Design-time soft conceptual aid** (vertical slice across the architecture), not a Branch Map entity — same status it has today. Phasing produces Phases; Plan produces Tasks; Parallelize groups Tasks into Waves. Slice is referenced in Design prose only.
+
+**Stage-commit naming consequence.** `stage-after-G{N}` → `stage-after-W{N}`. The branch ref name changes (`qrspi/{slug}/stage-after-G{N}` → `qrspi/{slug}/stage-after-W{N}`); existing on-disk branches from prior runs keep their G-named refs (forward-only rename).
+
+### 3.3 Sweep targets
+
+Confirmed sites (`grep -rnE "Parallel Group|parallel group|Dispatch Wave|stage-after-G"` across `skills/` and `agents/`):
+
+| File | Surface |
+|---|---|
+| `skills/parallelize/SKILL.md` | Lines 50, 60–62 (table), 72 (disambiguation paragraph — DELETE), 73, 75, 82, 88, 98, 101, 111, 114, 133–134 (terminal output example), 249, 259, 262, 289, 293–298 (Hybrid example table), 302–304 (Wave 1/Wave 2 narrative), 348, plus `stage-after-G` everywhere |
+| `skills/parallelize/owns-defers.md` | Lines 6–7 (file-overlap analysis prose) |
+| `skills/integrate/SKILL.md` | "Merge Strategy" section — references `stage-after-G{N}` and parallel-group concepts |
+| `skills/phasing/owns-defers.md` | Cross-skill reference to parallelize |
+| `agents/qrspi-parallelize-reviewer.md` | Reviewer body — references "parallel groups" / "dispatch waves" |
+| `tests/acceptance/test-hardening-skills.bats` | bats grep-guard text checking for "parallel group" terminology |
+| `skills/using-qrspi/SKILL.md` | Lines mentioning Wave / Group in Branch Model and Per-Round Commit prose |
+| `skills/implement/SKILL.md` | Wave references in dispatch logic prose |
+| `agents/qrspi-implement-gate-reviewer.md` | Wave / Group cross-references |
+
+Implementer's audit step: re-grep on PR-tip to confirm zero remaining `Parallel Group` / `parallel group` / `parallel-group` literals (the bats guard in §3.4 enforces this).
+
+The 200-word disambiguation paragraph at `skills/parallelize/SKILL.md:72` deletes entirely. It is replaced by a one-line definition at the same anchor:
+
+> **Wave:** A set of tasks that share a base AND have no file overlap. Wave numbering does not imply dispatch ordering — Implement's runtime rule is "dispatch every Wave whose dependencies are satisfied each tick."
+
+### 3.4 Test handling
+
+- **Update** `tests/acceptance/test-hardening-skills.bats` grep assertions that look for "parallel group" / "Parallel Group" — flip them to look for "Wave" instead, OR (preferred) reframe each existing assertion around what it's actually testing (e.g., "the parallelize artifact lists dispatch concurrency" rather than "the artifact uses the word 'group'"), so the test isn't coupled to vocabulary.
+- **Add** a regression guard in `tests/unit/` (new file: `test-no-parallel-group-vocab.bats`):
+
+  ```bash
+  #!/usr/bin/env bats
+  # Guards #41: "Parallel Group" / "parallel group" / "stage-after-G" must not
+  # reappear in skill or agent prose after the Group→Wave collapse. Allow-list
+  # any historical references in docs/superpowers/specs/ and reviews/ (frozen
+  # artifacts from before the rename).
+
+  @test "no Parallel Group vocabulary in skills/" {
+    local offenders
+    offenders=$(grep -rnE 'Parallel Group|parallel group|parallel-group' skills/ 2>/dev/null || true)
+    if [ -n "$offenders" ]; then
+      echo "legacy Parallel Group vocabulary remains:"
+      echo "$offenders"
+      return 1
+    fi
+  }
+
+  @test "no stage-after-G branch naming in skills/ or agents/" {
+    local offenders
+    offenders=$(grep -rnE 'stage-after-G[0-9{]' skills/ agents/ 2>/dev/null || true)
+    if [ -n "$offenders" ]; then
+      echo "legacy stage-after-G naming remains (should be stage-after-W):"
+      echo "$offenders"
+      return 1
+    fi
+  }
+
+  @test "no Parallel Group vocabulary in agents/" {
+    local offenders
+    offenders=$(grep -rnE 'Parallel Group|parallel group|parallel-group' agents/ 2>/dev/null || true)
+    if [ -n "$offenders" ]; then
+      echo "legacy Parallel Group vocabulary remains in agents/:"
+      echo "$offenders"
+      return 1
+    fi
+  }
+  ```
+
+  ~30 lines of bats; same shape as the legacy-pattern guards from #125.
+
+### 3.5 Out of scope
+
+- **F-23 Parallelize presentation cleanup.** F-23 is downstream — only makes sense after Group/Wave merge — but it's not in v0.5. Deferred to a future milestone. This spec touches the disambiguation paragraph; F-23 will touch the broader narrative shape later.
+- **Schema/runtime change to the dispatch loop.** Implement's existing wave-dispatch logic already implements the "dispatch every unblocked group concurrently" rule under different naming. This rename does not change runtime behavior — only how the rule is described.
+- **Reviewer-prompt regeneration.** Parallelize reviewer agent file gets the vocabulary update, but the reviewer's *checks* (file-overlap, symbolic-base vocabulary, stage commits, completeness) are unchanged.
+
+## 4. #90: Nested-Task Naming Convention for TaskCreate UI
+
+### 4.1 Problem
+
+Claude Code's TaskCreate has no nested-task support — no `parentId`, no subtask field, no indent-by-dependency renderer. QRSPI's natural hierarchy (Phase → Wave → Task → Subagent dispatch) is invisible in the task list. F-24 (`docs/qrspi/2026-04-26-findings.md`) flagged this; the workaround it proposes is a naming-prefix convention.
+
+### 4.2 Fix shape
+
+Adopt a one-line convention for sub-tasks under each Wave: prefix with `  └─ ` (two leading spaces + box-drawing tee). Document the convention once in `using-qrspi/SKILL.md`, then reference it from every SKILL that creates per-task TaskCreate entries.
+
+**Convention text** (added to `using-qrspi/SKILL.md` as a new short subsection within the existing TaskCreate guidance):
+
+```markdown
+### TaskCreate naming for QRSPI hierarchy
+
+Claude Code's TaskCreate has no native nested-task UI. To make QRSPI's hierarchy visible in the task list, use this naming convention:
+
+- **Phase / Wave parent task:** `Phase 2 / Wave 3 — auth endpoints`
+- **Sub-task under a Wave:** `  └─ task-04: validate JWT signature`
+
+Two leading spaces + the box-drawing tee (`└─`) indents the sub-task one level visually. The convention is naming-only — TaskCreate has no schema for nesting; orchestrators set parent status manually as sub-tasks complete. Do not introduce extra indentation levels (no `  ├─ ` or three-deep nesting); QRSPI is two levels max in the TaskCreate surface.
+```
+
+### 4.3 Sweep targets
+
+This is **additive prose only.** No existing TaskCreate sites need to be retroactively renamed in the source SKILLs — the convention applies at *runtime* TaskCreate calls the orchestrator makes, not in skill text. The only edits:
+
+- **Add** the convention subsection to `skills/using-qrspi/SKILL.md` (the umbrella every SKILL preloads).
+- **Optionally** add a one-line cross-reference in `skills/parallelize/SKILL.md` near where Wave dispatch is described, pointing at the convention. (Optional because the umbrella is already preloaded.)
+
+### 4.4 Test handling
+
+**No bats test.** The convention is a documentation guideline, not a runtime contract. Adding a grep that asserts "TaskCreate calls follow the convention" would require parsing TaskCreate invocations in skill text, but the runtime calls are *generated by the orchestrator*, not present as literal strings in the skills. Test debt would be misaligned with what the convention actually enforces.
+
+If a future PR adds a runtime hook that lints TaskCreate subjects, it could enforce this convention. Out of scope here.
+
+### 4.5 Out of scope
+
+- **F-22 / F-23 hierarchy work.** F-22 is #41 (this spec). F-23 is the parallelization-presentation cleanup deferred above.
+- **Engaging Claude Code on real nested-task UI** (`parentId` schema, indent renderer). Anthropic-side work; QRSPI uses the workaround until upstream support exists.
+- **Three-level nesting** (Phase → Wave → Task → Sub-task in the TaskCreate UI). YAGNI — QRSPI's natural depth is two levels at the TaskCreate surface; deeper hierarchy lives in the artifact tree.
+
+## 5. Sequence
+
+Single PR, **three commits** grouped by atomicity unit:
+
+1. **`docs(skills): #113 rename round-NN-fixes.md → round-NN-dispositions.md`** — touches `using-qrspi/SKILL.md` filename references, `tests/unit/test-verifier-dispatch-contract.bats:22` regex, `tests/unit/test-no-legacy-disk-write-references.bats:12` comment, and adds the new `round-NN-fixes\.md` legacy guard. Smallest blast radius; lands first.
+2. **`docs(skills): #41 collapse Parallel Group into Wave (Phase/Slice/Task/Wave)`** — sweeps every "Parallel Group" / "stage-after-G" site per §3.3, deletes the disambiguation paragraph at `parallelize/SKILL.md:72`, replaces with one-line definition, updates bats guards (`test-hardening-skills.bats` reframe + new `test-no-parallel-group-vocab.bats`).
+3. **`docs(using-qrspi): #90 add TaskCreate naming convention for QRSPI hierarchy`** — additive subsection in `using-qrspi/SKILL.md` only.
+
+Test plan:
+- `bats tests/unit/test-verifier-dispatch-contract.bats` — passes (regex updated to new filename).
+- `bats tests/unit/test-no-legacy-disk-write-references.bats` — passes (comment updated; new fixes-filename guard added at end of commit 1).
+- `bats tests/unit/test-no-parallel-group-vocab.bats` — passes after commit 2 (new file).
+- `bats tests/acceptance/test-hardening-skills.bats` — passes after commit 2 (vocabulary reframe).
+- `bats tests/unit/` full suite — same baseline failures as parent (`a1db28d`); no regressions.
+- Manual scan: open `parallelize/SKILL.md` and confirm the disambiguation paragraph is gone and Wave/Slice/Task vocabulary reads cleanly. Open `using-qrspi/SKILL.md` and confirm the new TaskCreate-naming subsection sits naturally next to existing TaskCreate prose.
+
+## 6. Backwards Compatibility
+
+Pure prose. No agent file invocation contract, schema, or routing impact. All three changes are forward-only renames or additions — historical on-disk artifacts (old `round-NN-fixes.md` files, branches named `stage-after-G{N}`) keep their existing names; new runs use the new names. The orchestrator does not need a migration shim.
+
+## 7. Closes
+
+- Closes #113
+- Closes #41
+- Closes #90

--- a/docs/superpowers/specs/2026-05-05-114-codex-audit-write-design.md
+++ b/docs/superpowers/specs/2026-05-05-114-codex-audit-write-design.md
@@ -1,0 +1,157 @@
+# #114: Delete the Codex Companion Audit-Write Surface
+
+**Status:** Design
+**Issue:** [#114](https://github.com/dfrysinger/qrspi-plus/issues/114)
+**Milestone:** v0.5
+**Date:** 2026-05-05
+
+## 1. Triage: the original symptom is already fixed
+
+Issue #114's reproduction string —
+
+```
+audit-write fail (exit 12): artifact_dir from state.json is not a directory: .../prompt-improvements
+```
+
+— came from the **prior** `state.json`-based audit-dir resolver inside `scripts/codex-companion-bg.sh`. That resolver was replaced during the #108/#110 hooks-removal sequence. The current resolver (`resolve_audit_dir`, lines 113–155) accepts a trusted-caller `--artifact-dir` CLI flag and never reads `state.json`. Verified by grep: zero `state\.json` references remain on the audit path. Part 1 of the issue ("fix the immediate exit 12") is already resolved.
+
+Spec E executes Part 2 — the audit-surface inventory and prune.
+
+## 2. Audit surface — what it currently does
+
+Per-`await` invocation, `emit_audit_row` appends one JSONL line to `<artifact_dir>/.qrspi/audit-codex-review.jsonl`:
+
+```json
+{"job_id":"...","elapsed_seconds":47,"completion_status":"completed","timestamp":"2026-05-06T..."}
+```
+
+That is the entirety of what the audit log captures: **operational telemetry only** — which dispatch ran, how long, did it complete or hit ceiling/error, when. Zero finding content. The actual review artifacts (`reviews/{step}/round-NN/<reviewer_tag>.finding-F<NN>.md`) are written by the reviewer agents directly to disk, not by codex-companion. Removing the audit log doesn't lose any review content.
+
+**Consumer inventory** (`grep -rln "audit-codex-review\.jsonl"` for *readers*):
+
+- No automated check reads the file.
+- No skill or agent body parses it.
+- No bats test asserts on its content beyond write-side unit tests.
+- Doc references (`launch-await-pattern.md`, `README.md`) describe *where* it's written, not how it's consumed.
+
+The log is forensic-only with **no current consumer** and is duplicative metadata: review presence is already trackable via the per-finding files committed each round.
+
+## 3. Fix shape: delete entirely
+
+Three options were considered:
+
+| Option | Action | Verdict |
+|---|---|---|
+| A | Keep as-is | ❌ Over-engineered for forensic-only log |
+| B | Best-effort warn-and-continue | ❌ Half-removal — leaves `--artifact-dir` mystery + dead JSONL on disk |
+| **C** | **Delete entirely + strip `--artifact-dir`** | ✅ **Selected** |
+
+Option C wins because the audit log has no consumer, no programmatic dependency, no security role under the post-hooks-removal threat model. Keeping it (Option A) or half-keeping it (Option B) means future readers still wonder why `audit-codex-review.jsonl` is on disk and why `await` requires `--artifact-dir`. Deleting both removes the question. If timing forensics ever become valuable again, re-introduction is cheaper than maintenance.
+
+### 3.1 What gets deleted
+
+**`scripts/codex-companion-bg.sh`:**
+- `resolve_audit_dir` function (lines 113–155, ~45 LOC)
+- `emit_audit_row` function (lines 158–end of definition, ~80 LOC)
+- `QRSPI_AUDIT_FILENAME`, `QRSPI_AUDIT_LOCK_NAME` constants (lines 50–51)
+- Audit-path-lockdown header comment (lines 42–49)
+- File-header exit-code 12 row (lines 24–26)
+- `file_mtime_epoch` helper (lines 86–93) — currently used only by the mkdir-lock stale-reap; dead after audit removal. (Keep if it has another caller; verify by grep.)
+- `--artifact-dir` flag handling in the `await` subcommand argument parser
+- All `emit_audit_row` callsites in `await_subcommand`
+
+**`skills/_shared/codex/launch-await-pattern.md`:**
+- Drop the `--artifact-dir` parameter from every documented invocation
+- Drop "**12** = audit-write fail …" from the exit-code list (exit codes go from 6 to 5: `0`, `10`, `11`, `13`, `14`)
+- Drop the explanatory prose about audit row writes
+
+**`skills/{research,design,using-qrspi,parallelize,test,goals,integrate,phasing,implement,replan,structure,questions}/SKILL.md`** (12 files):
+- Strip `--artifact-dir <ABS_ARTIFACT_DIR>` from every documented `codex-companion-bg.sh await` invocation. Confirmed sites: 22 occurrences across these 12 files plus the canonical template in `_shared/codex/launch-await-pattern.md`.
+
+**Tests:**
+- Delete `tests/unit/test-codex-companion-bg.bats` audit-related tests (~80 lines covering `emit_audit_row` write-success / failure / lock-contention / perm-enforcement / jq-escape / etc.)
+- Delete audit-related assertions in `tests/unit/test-using-qrspi.bats` (17 lines)
+
+**Docs:**
+- `README.md`: drop the audit-log path reference
+- `tests/unit/test-no-legacy-disk-write-references.bats:12` comment (already touched by Spec D §2.3 for the dispositions rename — this spec adds removal of `audit-codex-review.jsonl` from the comment's list of legitimate non-reviewer artifacts)
+
+### 3.2 What gets added
+
+**One regression-guard test** — `tests/unit/test-no-codex-audit-references.bats` (new):
+
+```bash
+#!/usr/bin/env bats
+# Guards #114: the codex-companion audit-write surface was removed in v0.5.
+# Reappearance of audit symbols in the script or dispatch sites would be a
+# regression — re-introduce only via an explicit issue.
+
+@test "codex-companion-bg.sh has no audit symbols" {
+  local offenders
+  offenders=$(grep -nE 'emit_audit_row|resolve_audit_dir|QRSPI_AUDIT_|audit-codex-review' \
+    scripts/codex-companion-bg.sh 2>/dev/null || true)
+  if [ -n "$offenders" ]; then
+    echo "audit symbols remain in codex-companion-bg.sh:"
+    echo "$offenders"
+    return 1
+  fi
+}
+
+@test "no skill or agent file passes --artifact-dir to codex-companion-bg.sh" {
+  local offenders
+  offenders=$(grep -rnE 'codex-companion-bg\.sh +await +.*--artifact-dir' \
+    skills/ agents/ 2>/dev/null || true)
+  if [ -n "$offenders" ]; then
+    echo "dispatch sites still pass --artifact-dir:"
+    echo "$offenders"
+    return 1
+  fi
+}
+
+@test "regression #114: no state.json read in codex-companion-bg.sh" {
+  local non_comment
+  non_comment=$(grep -nE '^[^#]*state\.json' scripts/codex-companion-bg.sh 2>/dev/null || true)
+  [ -z "$non_comment" ]
+}
+```
+
+Three assertions: audit-symbols-gone, dispatch-flag-gone, original-state.json-symptom-gone. ~25 lines bats.
+
+### 3.3 Trust-model implication
+
+The current header comment (lines 42–49) describes the audit-path lockdown as the trust boundary. With the audit gone, that boundary doesn't exist and the comment goes with it. The codex-companion's runtime no longer requires any caller-supplied path. `await` becomes argument-shape-simpler: `await <jobId>` instead of `await --artifact-dir <abs> <jobId>`.
+
+## 4. Sequence
+
+Single PR, **three commits**:
+
+1. **`refactor(scripts): #114 delete codex-companion audit-write code path`** — strip `resolve_audit_dir`, `emit_audit_row`, the audit constants, the audit-path-lockdown header comment, and the exit-code 12 row from the file-header table. Also drops `--artifact-dir` parsing from `await_subcommand`. The script's exit codes shrink from 6 to 5.
+2. **`docs(skills): #114 strip --artifact-dir from codex dispatch sites`** — sweep `_shared/codex/launch-await-pattern.md` plus the 12 SKILLs that follow it. Mechanical find-and-replace (same shape as the Spec D vocabulary sweep). Updates exit-code prose to reflect the 5-code list.
+3. **`test(unit): #114 delete audit tests + add regression guards`** — delete audit-related bats in `test-codex-companion-bg.bats` and `test-using-qrspi.bats`; add `test-no-codex-audit-references.bats`; update `test-no-legacy-disk-write-references.bats:12` comment.
+
+Test plan:
+- `bats tests/unit/test-codex-companion-bg.bats` — passes (audit tests deleted; remaining job-tracking tests still green).
+- `bats tests/unit/test-using-qrspi.bats` — passes (audit assertions deleted).
+- `bats tests/unit/test-no-codex-audit-references.bats` — passes (3/3 guard assertions).
+- `bats tests/unit/` full suite — same baseline failures as parent (`a1db28d`); no regressions.
+- Manual: dispatch a real codex review against any artifact_dir, confirm the JSONL file is not created and the dispatch result still arrives on stdout.
+
+## 5. Reviewer Suite
+
+This is runtime-touching code (`scripts/codex-companion-bg.sh`). The qrspi-plus prose-handling preference does **not** apply. Full reviewer suite required: spec-review, code-quality, security, silent-failure, goal-traceability, test-coverage. Implement-stage gate enabled.
+
+## 6. Backwards Compatibility
+
+- **Pre-existing `audit-codex-review.jsonl` files on disk** stay untouched (gitignored; not consumed by anything).
+- **Callers passing `--artifact-dir` after deletion** see "unknown option" from `await`'s arg parser. This is intentional — the dispatch sites are swept in commit 2 of the same PR; any out-of-tree caller still passing the flag is signaling stale code that needs updating.
+- **No data migration.** Forensic-only log with no consumer; deletion is forward-only.
+
+## 7. Out of scope
+
+- **Deleting the legacy hook-layer audit code** (`hooks/lib/audit.sh`, `hooks/pre-tool-use` audit references, `tests/unit/test-audit.bats`, `tests/unit/test-state.bats`). Tracked separately by the dead-hooks cleanup memory; that work is broader than #114's scope and includes the entire `hooks/` tree.
+- **Re-introducing structured telemetry** (e.g., OpenTelemetry traces for codex jobs). YAGNI; re-introduce only when a consumer exists.
+- **Regression test running an actual codex job end-to-end.** Out of scope for unit-test CI; integration smoke is a manual post-merge step.
+
+## 8. Closes
+
+- Closes #114


### PR DESCRIPTION
## Summary

v0.5 spec round 4. 

- **Spec D — `2026-05-05-113-41-90-prose-bundle-design.md`** — prose bundle for #113 (`round-NN-fixes.md` → `round-NN-dispositions.md` rename) + #41 (collapse Parallel Group into Wave; Phase/Slice/Task/Wave 4-level vocabulary; rename `stage-after-G{N}` → `stage-after-W{N}`) + #90 (TaskCreate naming convention `  └─ task-NN ...`). Three commits, no schema/runtime impact, bats grep-guards only. Per qrspi-plus prose-handling preference: **lightweight reviewer suite, no TDD ceremony.**

- **Spec E — `2026-05-05-114-codex-audit-write-design.md`** — **delete the codex companion audit-write surface entirely.** The `state.json` exit-12 symptom in #114 is already fixed by post-#108 hooks-removal. Audit log inventory found zero programmatic consumers and the data is duplicative metadata (per-finding files already committed each round). Spec strips `resolve_audit_dir`, `emit_audit_row`, `--artifact-dir` parsing in `await`, and the flag at 22 dispatch sites across 13 SKILL files. Net: ~200 LOC code + ~100 LOC tests removed; one regression-guard bats added. Three commits. **Full reviewer suite required** (runtime-touching).

- **Spec F — `2026-05-05-112-scope-tag-derivation-design.md`** — convergence-driven diff narrowing via dedicated `qrspi-scope-tagger` Haiku subagent. Two mechanisms from the optimization plan's Combined Opts #2 + #7 bundled:
  - **Mechanism A:** orchestrator runs `git diff <ref> > round-NN.diff` via Bash redirect; both reviewers Read the same file (diff content never enters main chat).
  - **Mechanism B:** scope-tagger subagent reads kept findings post-verifier-fan-in, derives `scope_tag` per finding (file path for multi-file artifacts; H2 heading for single-file artifacts), emits `round-NN-scope-set.txt`. Orchestrator compares scope-sets across rounds and narrows next round's dispatch on convergence.

  **Refined convergence rule** (extends the plan's `|scope_set| ≤ 1` form): narrow if `scope_set(N) == scope_set(N-1)` (any size); narrow to the broader set if `scope_set(N) ⊂ scope_set(N-1)` (safety margin); broaden in any other case. When narrowed, dispatch uses `ref=HEAD~1` plus an advisory `scope_hint` in reviewer prompts. **Recommends two-PR implementation split**: PR-1 Mechanism A only, PR-2 tagger + convergence narrowing. **Full reviewer suite required.**

## Order

Suggested implementation sequence: **D → E → F.**

1. **D first** because it's prose-only and lowest blast radius; ships the rename (#113) that #112's `round-NN-dispositions.md` references depend on.
2. **E second** because it's a contained surface-deletion with narrow scope; gets the codex companion to a simpler shape before F's heavier orchestration work lands on top.
3. **F last** because it's the heaviest of the three; benefits from a stable simplified codex companion underneath it.

## Open questions / decisions baked in

- **Spec D §3.2** — committed to "Wave is the surviving name; concurrency derives from Wave dependency graph at runtime, not from 'Waves can contain multiple Groups.'" The example at `parallelize/SKILL.md:304` (two groups in one wave) becomes "two Waves dispatched concurrently when their dependencies are satisfied." Confirm this interpretation matches your read of #41 before implementation.
- **Spec E §3.1** — committed to deleting `--artifact-dir` from `await`'s arg parser (clean removal) rather than keeping it as a deprecated no-op. Forces the 22-site sweep but leaves no mystery flag behind.
- **Spec F §2.4** — committed to the refined convergence rule (subset narrows to broader set; equal narrows to same set; superset/partial-overlap/disjoint broadens). Less aggressive than narrow-to-current; more aggressive than the plan's strict `|scope_set| ≤ 1`.
- **Spec F §2.3** — single-file artifact granularity = **H2** (start coarser, reconsider H3 later if narrowing fires too rarely).
- **Spec F §5** — recommends two-PR implementation split. Confirm whether to plan as single-PR or split.

## Test plan

- [x] `git status` clean on `qrspi-echo/v0.5-spec-round-4`
- [x] All three spec files committed in a single commit (`dd9faf4`)
- [ ] User reviews each spec doc and provides feedback / approves
- [ ] On approval, each spec spawns its own implementation branch (D/E/F separately, not bundled — implementations are independently sized and have different reviewer-suite requirements)

## Closes (specs only — issues close when implementation lands)

Specs reference #113, #41, #90, #114, #112. Each issue stays open until its implementation PR closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
