### PR TITLE
fix(qrspi): verifier rubric — iron-law floor + anti-anchoring

### DIFF
--- a/agents/qrspi-finding-verifier.md
+++ b/agents/qrspi-finding-verifier.md
@@ -12,7 +12,7 @@ Score each finding on a continuous 0–100 integer scale. The anchors below are 
 a. **0:** Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
 b. **25:** Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not explicitly called out in the relevant CLAUDE.md.
 c. **50:** Moderately confident. The agent was able to verify this is a real issue, but it might be a nitpick or not happen very often in practice. Relative to the rest of the PR, it's not very important.
-d. **75:** Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach in the PR is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
+d. **75:** Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach in the PR is insufficient. The issue is very important and will directly impact the code's functionality, **or violates a documented "Iron Law", "Iron Rule", "MUST", or equivalent explicitly-load-bearing constraint in an upstream SKILL.md, agent file, or CLAUDE.md**, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
 e. **100:** Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
 
 ## False-positive examples


### PR DESCRIPTION
## Summary

Single substantive change to the `qrspi-finding-verifier` rubric: extend anchor (d) to treat documented "Iron Law" / "Iron Rule" / "MUST" constraints in upstream SKILL.md or agent files as the prose-artifact equivalent of a CLAUDE.md rule.

## What was breaking

The 75-anchor previously named **"directly impact code's functionality"** or **"directly mentioned in CLAUDE.md"** as the qualifying-importance criteria. For prose artifacts (goals, questions, design, etc.) neither criterion binds: an iron-law violation isn't code-functionality, and SKILL.md isn't CLAUDE.md.

The verifier was honestly placing confirmed iron-law violations between the 50-anchor ("moderate, might be nitpick") and the 75-anchor it couldn't cleanly reach — landing in the 60s-70s gap. The score wasn't wrong; the rubric was under-specified for prose artifacts.

## What stays out

The 80 keep/drop threshold lives only in `using-qrspi/SKILL.md` (orchestrator side). The verifier remains threshold-unaware: it just produces an honest score against rubric anchors, and the orchestrator's assembly script applies the cutoff. **This patch does not introduce threshold knowledge into the verifier.** Earlier iterations of this PR included an explicit "iron-law floor at 80" and an "anti-anchoring" directive that referenced the 65-79 band — those have been removed; the (d) extension alone is sufficient.

## Validation

Re-ran the verifier on four committed round-2 findings of a Questions artifact (sidecars to `/tmp` to keep evidence clean):

| Finding | Old | New | Δ | Routing |
|---|---|---|---|---|
| claude.R2-F01 (iron-law goal-leakage) | 68 | **80** | +12 | KEPT (was dropped) |
| codex.R2-F01 (iron-law goal-leakage) | 78 | **90** | +12 | KEPT (was dropped) |
| claude.R2-F02 (Q13/Q16 overlap) | 70 | **78** | +8 | drop (same) |
| codex.R2-F02 (broad overlap) | 70 | **25** | −45 | drop (same) |

Both iron-law findings cleanly cleared 75 via the new (d) criterion (verified-real evidence pushed them to 80/90). Non-iron-law overlap findings stayed in moderate-or-low band. All four routing decisions are correct.

The new sidecar `reason:` lines explicitly cite "Iron Law violation of upstream SKILL.md" for the kept findings, confirming the verifier is using the new rubric vocabulary rather than just landing on numbers that happen to match.

## Test plan

- [x] Re-verify four prior round-2 findings — all four scores moved correctly
- [x] Inspect new `reason:` strings — verifier explicitly cites "Iron Law" / "Iron Rule" criterion from anchor (d), not threshold-anchored numbers
- [x] Confirm no threshold (80) reference enters the verifier file — verifier remains threshold-unaware
- [ ] Apply on next live QRSPI round (any in-flight session benefits immediately on plugin update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
