### PR TITLE
docs(readme): mark Copilot CLI marketplace install as primary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,7 +679,9 @@ copilot plugin marketplace add dfrysinger/qrspi-plus
 copilot plugin install qrspi@qrspi-plus
 ```
 
-Or install the repo directly:
+Or install the repo directly (shows a deprecation warning — direct
+repo/URL installs are slated for removal in a future Copilot CLI
+release):
 
 ```bash
 copilot plugin install dfrysinger/qrspi-plus

--- a/README.md
+++ b/README.md
@@ -672,24 +672,31 @@ Claude reads `.claude-plugin/plugin.json` and auto-discovers `agents/` and
 
 ### GitHub Copilot CLI
 
+**Recommended — install from the qrspi-plus self-marketplace** (no
+deprecation warning):
+
+```bash
+copilot plugin marketplace add dfrysinger/qrspi-plus
+copilot plugin install qrspi@qrspi-plus
+```
+
+**Alternative — direct repo install** (surfaces a deprecation warning
+because direct repo/URL installs will eventually require a marketplace
+backing in a future Copilot CLI release):
+
 ```bash
 copilot plugin install dfrysinger/qrspi-plus
 ```
 
-Copilot CLI reads `.github/plugin/plugin.json`, enumerating the 16 skills
-under `skills/` and the 41 agents under `agents/`.
-
-> **Note on direct installs.** The Copilot CLI currently surfaces a
-> deprecation warning when installing from a repo or URL ("only
-> `plugin@marketplace` installs will be supported in a future release").
-> Once a hosting marketplace is published, the install command will become
-> `copilot plugin install qrspi@<marketplace>`. The repo already ships a
-> `.github/plugin/marketplace.json` to make that registration trivial.
+Either path enumerates the 16 skills under `skills/` and the 41 agents
+under `agents/`. The repo ships both `.github/plugin/plugin.json` (the
+plugin manifest) and `.github/plugin/marketplace.json` (the self-hosted
+marketplace listing).
 
 ### Notes on cross-CLI behavior
 
-- **Agent frontmatter.** Agent files use the Claude scalar `tools: Read, Write, Bash, ...` form. Copilot CLI tolerates this. The same agents work in both CLIs.
-- **`skills:` auto-load directive.** A few agents declare `skills: [reviewer-protocol]` in frontmatter. This is a Claude convention; under Copilot CLI it is informational only and does not auto-load. The agent body still reads cleanly because it dispatches to the skill explicitly where needed.
+- **Agent frontmatter.** Agent files use the Claude scalar `tools: Read, Write, Bash, ...` form. Copilot CLI accepts this form as-is — no rewrite needed. The same agents work in both CLIs.
+- **`skills:` auto-load directive.** A few agents declare `skills: [reviewer-protocol]` in frontmatter. Both Claude Code and Copilot CLI honor this and preload the listed skill bodies into the agent's context at activation.
 - **No hook layer.** qrspi-plus does not register any tool-lifecycle hooks. All enforcement (artifact gating, task allowlists, TDD discipline) is prompt-side, defined in the skills and agent files.
 
 After installation, the `using-qrspi` skill is the entry point. The pipeline activates whenever the user wants to build something.

--- a/README.md
+++ b/README.md
@@ -672,17 +672,14 @@ Claude reads `.claude-plugin/plugin.json` and auto-discovers `agents/` and
 
 ### GitHub Copilot CLI
 
-**Recommended — install from the qrspi-plus self-marketplace** (no
-deprecation warning):
+Install from the qrspi-plus self-marketplace:
 
 ```bash
 copilot plugin marketplace add dfrysinger/qrspi-plus
 copilot plugin install qrspi@qrspi-plus
 ```
 
-**Alternative — direct repo install** (surfaces a deprecation warning
-because direct repo/URL installs will eventually require a marketplace
-backing in a future Copilot CLI release):
+Or install the repo directly:
 
 ```bash
 copilot plugin install dfrysinger/qrspi-plus
@@ -695,8 +692,8 @@ marketplace listing).
 
 ### Notes on cross-CLI behavior
 
-- **Agent frontmatter.** Agent files use the Claude scalar `tools: Read, Write, Bash, ...` form. Copilot CLI accepts this form as-is — no rewrite needed. The same agents work in both CLIs.
-- **`skills:` auto-load directive.** A few agents declare `skills: [reviewer-protocol]` in frontmatter. Both Claude Code and Copilot CLI honor this and preload the listed skill bodies into the agent's context at activation.
+- **Agent frontmatter.** Agent files use the Claude scalar `tools: Read, Write, Bash, ...` form. Both CLIs accept it.
+- **`skills:` auto-load directive.** A few agents declare `skills: [reviewer-protocol]` in frontmatter. Both CLIs preload the listed skill bodies into the agent's context at activation.
 - **No hook layer.** qrspi-plus does not register any tool-lifecycle hooks. All enforcement (artifact gating, task allowlists, TDD discipline) is prompt-side, defined in the skills and agent files.
 
 After installation, the `using-qrspi` skill is the entry point. The pipeline activates whenever the user wants to build something.


### PR DESCRIPTION
Small README correction tied to follow-up from PR #193:

1. **Self-marketplace install is the recommended path** — `copilot plugin marketplace add dfrysinger/qrspi-plus` + `copilot plugin install qrspi@qrspi-plus` works today (verified end-to-end on Copilot CLI 1.0.55). README L686's placeholder note ("once a hosting marketplace is published…") was obsolete.

2. **`skills:` auto-load note corrected.** [github/copilot-cli#3532](https://github.com/github/copilot-cli/issues/3532) is closed (resolved upstream) — Copilot CLI honors the `skills:` frontmatter and preloads listed skill bodies into the agent's context. The README's "informational only and does not auto-load" note reflected the pre-fix state.

Direct repo install path retained as 'Alternative' so users with old install scripts still have a documented fallback.

## Verification

```
$ copilot plugin marketplace add dfrysinger/qrspi-plus
Marketplace "qrspi-plus" added successfully.
$ copilot plugin install qrspi@qrspi-plus
Plugin "qrspi" installed successfully. Installed 16 skills.
$ copilot plugin list | grep qrspi
  • qrspi@qrspi-plus (v0.2.0)
```

41/41 agents present in install cache. No deprecation warning.

Related: #196 (tracks future submission to default-registered marketplaces).
