### PR TITLE
docs: generalize contributor protocol; retire bot-identity machinery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent protocol for qrspi-plus
 
 Before starting any task in this repository, read [`CONTRIBUTING.md`](CONTRIBUTING.md)
-for the full agent + maintainer protocol — issue triage labels,
+for the full agent and maintainer protocol: issue triage labels,
 branch-naming convention, commit and PR rules, CI expectations, and
 the optional parallel-agent workflow pattern.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
 # Agent protocol for qrspi-plus
 
 Before starting any task in this repository, read [`CONTRIBUTING.md`](CONTRIBUTING.md)
-for the full agent + maintainer protocol — bot identities, `qas`
-authentication, branch-prefix convention, commit/PR rules, issue triage
-conventions, and project-board commands.
+for the full agent + maintainer protocol — issue triage labels,
+branch-naming convention, commit and PR rules, CI expectations, and
+the optional parallel-agent workflow pattern.
 
 This pointer file auto-loads in Copilot CLI / Claude Code sessions
 opened at the qrspi-plus repo root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,199 +1,125 @@
 # Contributing to qrspi-plus
 
-This file documents the agent + maintainer protocol for this repository.
-If you opened a Copilot CLI / Claude Code session in the qrspi-plus
-repo root, the slim `AGENTS.md` at the root pointed you here.
+Thanks for working on qrspi-plus. This file is the agent + maintainer
+protocol for this repository — issue triage conventions, branch and
+commit rules, CI expectations, and the optional parallel-agent
+workflow pattern. The slim `AGENTS.md` at the repo root points
+Copilot CLI / Claude Code sessions to this file when they auto-load.
 
-You are an agent with your own GitHub identity. All 7 agents are GitHub
-Apps named `qrspi-{nato}` (alpha, bravo, charlie, delta, echo, foxtrot,
-golf) —they commit and comment as `qrspi-{nato}[bot]`.
+## Issue triage
 
-The human reviewer is `@dfrysinger`.
+Every new issue and PR should carry the following labels (the
+maintainer adds them on triage if you don't):
 
-Branch prefix matches your bot handle without the `[bot]` suffix:
-e.g. `qrspi-alpha/...`.
+- **One type label** — `bug`, `enhancement`, `documentation`, or
+  `question`.
+- **One `area:*` label** — the QRSPI step or surface the change
+  touches. Valid areas: `area:goals`, `area:questions`, `area:research`,
+  `area:design`, `area:phasing`, `area:structure`, `area:plan`,
+  `area:parallelize`, `area:implement`, `area:integrate`, `area:test`,
+  `area:replan`, `area:state`, `area:codex`, `area:docs`,
+  `area:harness`, `area:hooks`.
+- **One `priority:*` label** — `priority:high`, `priority:medium`, or
+  `priority:low`.
+- **`needs-triage`** — until a maintainer has reviewed and accepted
+  the issue, this label stays. Maintainers remove it after applying
+  type + area + priority and adding the issue to the project board.
 
-Each CC session lives in a folder named `agent-{nato}` under
-`~/Library/CloudStorage/Dropbox/claude-workspace/`. The folder name is
-the source of truth for which identity that session uses.
+Milestones are inherently time-bound, not evergreen: a milestone
+appears on an issue only when a maintainer has scheduled it for a
+specific release. Issues with no milestone are in the icebox. Agents
+do not reassign milestones; that's a maintainer call.
 
-## Bootstrapping a session
+## Branch naming
 
-When starting a fresh Claude Code session as an agent:
+Use descriptive prefixes that signal intent:
 
-1. Open the session in its `agent-{nato}` folder. The root `AGENTS.md`
-   auto-loads once you are in the qrspi-plus repo root and points you
-   at this file (`CONTRIBUTING.md`) for the full protocol.
-2. Read the kickoff message from the human for the issue assignment.
-3. Authenticate by running `qas` (auto-detects nato from `$PWD`) — see
-   "Authenticating" below.
-4. Confirm your identity matches what the human addressed; the `qas`
-   output line shows it (`qas: qrspi-{nato}[bot] (expires …)`). The
-   `gh api user` endpoint is **not** accessible to installation tokens,
-   so don't use it for verification — `qas --who` reads the cached
-   identity instead.
-5. Follow "Before starting any task" below.
+- `feat/<slug>` — new feature or capability.
+- `fix/<slug>` — bug fix.
+- `docs/<slug>` — documentation only.
+- `refactor/<slug>` — restructuring with no behavior change.
+- `test/<slug>` — test-only changes.
+- `chore/<slug>` — tooling, CI, dependencies, cleanup.
 
-## Authenticating
+If you are running multiple parallel agent sessions on this repo (see
+the "Parallel agents" section below), prefix branches with your agent
+handle so concurrent work is visually separable: e.g.
+`my-handle/fix/cli-help-text`.
 
-### Canonical: `qas`
+## Commits and pull requests
 
-Source the helper once in your shell config (one-time setup):
+- Use `gh` (the GitHub CLI) for issue and PR operations from the
+  command line. PRs land via the GitHub UI's standard squash-or-merge
+  flow.
+- Commit messages follow the Conventional-Commits style
+  (`type(scope): subject`). The same prefixes as branch names apply
+  (`feat`, `fix`, `docs`, `refactor`, `test`, `chore`).
+- When an LLM (Copilot, Claude, etc.) helped author a commit, append
+  the appropriate `Co-authored-by:` trailer. Copilot's trailer is:
+  `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
+- Keep PR bodies focused. The first paragraph states what changed and
+  why; remaining sections cover scope, verification, and any
+  follow-ups. Reference issues with `Closes #N` so the merge
+  auto-closes them.
 
-```
-# in ~/.zshrc
-source "$HOME/Library/CloudStorage/Dropbox/claude-workspace/agent-tooling/playwright-signup/qas-init.sh"
-```
+## CI expectations
 
-Then in any new shell, inside the `agent-{nato}` folder:
+Every PR runs the following checks:
 
-```
-qas              # auto-detects nato from $PWD, mints token, exports GH_TOKEN
-qas alpha        # explicit override (use when working outside an agent dir)
-qas --who        # print currently-cached identity, don't re-mint
-```
+- **Lint** — `shellcheck` + a bash:3.2 ban-list grep across `scripts/`,
+  `agents/`, and `skills/`. The ban-list catches bash 4+ constructs
+  that break in the bash:3.2 alpine harness (e.g. `${var,,}`,
+  `mapfile`, `readarray`, `declare -A`).
+- **BATS under bash 3.2** — the full unit + acceptance test suites
+  run inside an alpine `bash:3.2` Docker image to guarantee no test
+  silently relies on a bash 4+ feature.
+- **CodeQL** — JavaScript/TypeScript + GitHub Actions analysis.
 
-`qas` does four things:
+All checks must be green before merge. If a CI failure looks
+unrelated to your change, mention it in the PR body so the maintainer
+can confirm.
 
-1. Mints a fresh installation token via `mint-installation-token.mjs`.
-2. Exports `GH_TOKEN` so `gh` and `git push` (over HTTPS via gh's
-   credential helper) act as the bot.
-3. Sets `git config user.name` + `user.email` for the current repo to
-   the bot's noreply identity.
-4. Prints `qas: qrspi-{nato}[bot] (expires <iso8601>)`.
+## Parallel agents (optional pattern)
 
-The token is scoped to `dfrysinger/qrspi-plus` only and expires in
-1 hour. Re-run `qas` if you see auth errors during a long session.
+This repo is designed to support concurrent agent sessions working on
+distinct issues in parallel. The pattern, in the most generic form:
 
-### Reference: manual mint (what `qas` does under the hood)
+1. Maintain one clone per agent session (separate working trees, or
+   `git worktree` from a shared bare clone).
+2. In each clone, set a per-clone git author name so commits are
+   visually distinguishable in `git log` and the PR UI:
 
-Each app's credentials live in 1Password (`Agent Vault`, item title
-`GitHub App - qrspi-{nato}`):
-
-- `app_id` (text)
-- `installation_id` (text)
-- `private_key` (concealed, RSA PEM)
-
-The canonical mint logic (any operator can implement this from scratch):
-
-1. Build a JWT signed `RS256` with the private key:
-   `header={alg:RS256}`, `payload={iat:now-60, exp:now+540, iss:app_id}`.
-   The `iat:now-60` backdate (60 seconds) absorbs clock skew between
-   your machine and GitHub; the `exp:now+540` window (9 minutes) sits
-   safely under GitHub's 600-second JWT-validity ceiling so a slow
-   request cannot expire the JWT mid-flight. These are NOT typos —
-   GitHub rejects any JWT whose `exp` is more than 600s after `iat`.
-2. POST `https://api.github.com/app/installations/{installation_id}/access_tokens`
-   with `Authorization: Bearer <jwt>`. The response body's `token`
-   field is the **installation token** — distinct from the JWT above
-   and with a different (1-hour) validity window.
-3. Use the returned installation token as `GH_TOKEN` for `gh` and as
-   the git password over HTTPS
-   (`https://x-access-token:<token>@github.com/...`).
-
-## Before starting any task
-
-1. Run `gh issue list --state open` and pick (or accept) one.
-2. Run `gh pr list --state open` and `gh pr diff <num>` for any PR
-   touching files near yours, so you don't step on a sibling agent.
-3. Self-assign the issue: `gh issue edit <num> --add-assignee @me`.
-4. On the project board, move your issue's **Status** field from
-   `Backlog` to `In Progress` (see "Project board" below).
-
-## Starting work
-
-5. Branch name: `{your-handle}/issue-{NNN}-{short-slug}`
-   (e.g. `qrspi-alpha/issue-42-fix-plan-stage-loop`).
-6. Make a stub commit and open a **draft** PR with body `Fixes #NNN`:
+   ```sh
+   git config --local user.name  "<your-agent-handle>"
+   git config --local user.email "<your-github-id>+<your-username>@users.noreply.github.com"
    ```
-   gh pr create --draft --title "..." --body "Fixes #NNN"
-   ```
-7. Append a line for yourself in `STATUS.md` and push.
-8. Initialize the review-tray comment on this PR using the template at
-   `docs/review-tray-template.md`.
 
-## While working
+   The noreply email is your existing GitHub-attributed identity.
+   GitHub still attributes commits to your account on the
+   contribution graph; the displayed author name is your agent
+   handle.
+3. Use the agent handle as the branch prefix
+   (`<your-agent-handle>/fix/...`) so concurrent branches don't
+   collide.
+4. Push under your normal `gh auth` token — no extra setup.
 
-9. Push commits frequently — the PR diff is your visible workspace.
-10. After every push that produces or updates an `.md` artifact:
-    - Edit the review-tray comment to reflect current state
-      (move files between 🟡 Ready / ⚪ In progress / ✅ Approved).
-    - If a new artifact is ready for human review, post a separate short
-      comment `@dfrysinger ready for {file}` to trigger a notification.
-11. If blocked, comment on the issue and add the `blocked` label.
+This pattern requires no extra infrastructure beyond a working
+`gh auth` session.
 
-## Finishing
+## Status tracking
 
-12. Run `gh pr ready <num>` to flip draft → Ready for review, then
-    `@`-mention `@dfrysinger`.
-13. Address review comments by pushing more commits to the same branch.
-    Do not force-push.
-14. After merge, set the project Status field to `Done`.
+`STATUS.md` is an optional coordination file for in-flight work
+across multiple parallel agent sessions. An agent that takes a task
+appends a line at start; the same agent edits the line on completion
+or hand-off. Solo contributors can ignore it.
 
-## Never
+## Maintainer notes
 
-- Push directly to `main`.
-- Force-push a branch a sibling agent might be reading.
-- Merge your own PR.
-- Post or commit as a different agent's identity.
-- Reassign milestones without explicit human direction.
-- Drag-rank items in the project board — that's a human decision.
+These items apply only to the repository maintainer:
 
-## Issue triage conventions
-
-**Labels** — combine where relevant:
-
-- **Type:** `bug` / `enhancement` / `question` / `documentation`
-- **Area** (where the change lives): `area:goals`,
-  `area:design`, `area:structure`, `area:plan`, `area:parallelize`,
-  `area:implement`, `area:integrate`, `area:test`, `area:replan`,
-  `area:state`, `area:codex`, `area:docs`, `area:harness`
-- **Priority:** `priority:high` / `priority:medium` / `priority:low`
-- **Status modifiers:** `needs-triage` (not yet reviewed by maintainer),
-  `blocked` (waiting on something)
-
-**Milestones:**
-
-Milestones reflect the live planning state and change over time —
-query the canonical list with:
-
-```
-gh api repos/dfrysinger/qrspi-plus/milestones --jq '.[] | {title,state}'
-```
-
-Conventions agents should follow:
-
-- **`Icebox`** is the standing bucket for issues that are explicitly
-  deferred (formal goals scoped to a future phase). Treat it as a
-  durable label, not a release.
-- **No milestone assigned** = `needs-triage`. The human will scope it
-  into a release on the next planning pass.
-- Agents do not reassign milestones (see "Never" above) — leave the
-  field as the human set it, including leaving it unset.
-
-**When creating a new issue:** assign `needs-triage`, the relevant
-`area:*`, and `priority:*` if known. **Leave the milestone unset** unless
-the human told you which release it belongs to.
-
-## Project board
-
-One Projects (v2) board: **QRSPI-plus** —
-`https://github.com/users/dfrysinger/projects/1`.
-
-- **Add new issues to the project** on creation:
-  ```
-  gh project item-add 1 --owner dfrysinger --url <issue-url>
-  ```
-- The board has a **Status** field with options `Backlog` / `In Progress`
-  / `Done`. New items default to `Backlog`.
-- **Updating Status** requires the GraphQL mutation
-  `updateProjectV2ItemFieldValue`. The project node ID is
-  `PVT_kwHOABW9CM4BWBaN` and the Status field ID is
-  `PVTSSF_lAHOABW9CM4BWBaNzhRY5go`. Capture your item's node ID with
-  `--format json` on `gh project item-add`. Set only your own item; the
-  human handles bulk Status updates.
-- **Stack rank** is human-managed by drag-and-drop in the roadmap view
-  (grouped by milestone). The order persists across views as long as no
-  Sort is applied. Don't manage rank programmatically.
-- **Picking work from the queue:** prefer the top-ranked `priority:high`
-  items in `Backlog` with no current assignee.
+- Project board: add new issues and PRs via
+  `gh project item-add 1 --owner dfrysinger --url <url>`.
+- Milestone assignment is at the maintainer's discretion; agents
+  don't self-assign.
+- The dual-review skill (`/dual-review-local`) is the canonical
+  pre-merge review step for non-trivial diffs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,29 @@
 # Contributing to qrspi-plus
 
-Thanks for working on qrspi-plus. This file is the agent + maintainer
-protocol for this repository — issue triage conventions, branch and
-commit rules, CI expectations, and the optional parallel-agent
-workflow pattern. The slim `AGENTS.md` at the repo root points
-Copilot CLI / Claude Code sessions to this file when they auto-load.
+Thanks for working on qrspi-plus. This file is the agent and
+maintainer protocol for this repository: issue triage conventions,
+branch and commit rules, CI expectations, and the optional
+parallel-agent workflow pattern. The slim `AGENTS.md` at the repo
+root points Copilot CLI and Claude Code sessions to this file when
+they auto-load.
 
 ## Issue triage
 
 Every new issue and PR should carry the following labels (the
 maintainer adds them on triage if you don't):
 
-- **One type label** — `bug`, `enhancement`, `documentation`, or
+- **One type label**: `bug`, `enhancement`, `documentation`, or
   `question`.
-- **One `area:*` label** — the QRSPI step or surface the change
-  touches. Valid areas: `area:goals`, `area:questions`, `area:research`,
-  `area:design`, `area:phasing`, `area:structure`, `area:plan`,
-  `area:parallelize`, `area:implement`, `area:integrate`, `area:test`,
-  `area:replan`, `area:state`, `area:codex`, `area:docs`,
+- **One `area:*` label**: the QRSPI step or surface the change
+  touches. Valid areas: `area:goals`, `area:design`, `area:structure`,
+  `area:plan`, `area:parallelize`, `area:implement`, `area:integrate`,
+  `area:test`, `area:replan`, `area:state`, `area:codex`, `area:docs`,
   `area:harness`, `area:hooks`.
-- **One `priority:*` label** — `priority:high`, `priority:medium`, or
+- **One `priority:*` label**: `priority:high`, `priority:medium`, or
   `priority:low`.
-- **`needs-triage`** — until a maintainer has reviewed and accepted
-  the issue, this label stays. Maintainers remove it after applying
-  type + area + priority and adding the issue to the project board.
+- **`needs-triage`**: applied until a maintainer has reviewed and
+  accepted the issue. Maintainers remove it after applying type,
+  area, priority, and adding the issue to the project board.
 
 Milestones are inherently time-bound, not evergreen: a milestone
 appears on an issue only when a maintainer has scheduled it for a
@@ -34,16 +34,16 @@ do not reassign milestones; that's a maintainer call.
 
 Use descriptive prefixes that signal intent:
 
-- `feat/<slug>` — new feature or capability.
-- `fix/<slug>` — bug fix.
-- `docs/<slug>` — documentation only.
-- `refactor/<slug>` — restructuring with no behavior change.
-- `test/<slug>` — test-only changes.
-- `chore/<slug>` — tooling, CI, dependencies, cleanup.
+- `feat/<slug>`: new feature or capability.
+- `fix/<slug>`: bug fix.
+- `docs/<slug>`: documentation only.
+- `refactor/<slug>`: restructuring with no behavior change.
+- `test/<slug>`: test-only changes.
+- `chore/<slug>`: tooling, CI, dependencies, cleanup.
 
 If you are running multiple parallel agent sessions on this repo (see
 the "Parallel agents" section below), prefix branches with your agent
-handle so concurrent work is visually separable: e.g.
+handle so concurrent work is visually separable, e.g.
 `my-handle/fix/cli-help-text`.
 
 ## Commits and pull requests
@@ -64,20 +64,24 @@ handle so concurrent work is visually separable: e.g.
 
 ## CI expectations
 
-Every PR runs the following checks:
+Every PR runs the following checks (see `.github/workflows/ci.yml`
+for the source of truth):
 
-- **Lint** — `shellcheck` + a bash:3.2 ban-list grep across `scripts/`,
-  `agents/`, and `skills/`. The ban-list catches bash 4+ constructs
-  that break in the bash:3.2 alpine harness (e.g. `${var,,}`,
-  `mapfile`, `readarray`, `declare -A`).
-- **BATS under bash 3.2** — the full unit + acceptance test suites
-  run inside an alpine `bash:3.2` Docker image to guarantee no test
-  silently relies on a bash 4+ feature.
-- **CodeQL** — JavaScript/TypeScript + GitHub Actions analysis.
+- **Lint (shellcheck + bash32 ban-list)**: `shellcheck --severity=error`
+  plus a grep ban-list applied to `*.sh` and `*.bash` files under
+  `scripts/` and `tests/helpers/`. The ban-list rejects bash 4+
+  constructs that break under the bash:3.2 alpine harness: `mapfile`,
+  `declare -A`, `${var,,}` / `${var^^}` lowercasing/uppercasing,
+  `coproc`, and `wait -n`.
+- **BATS under bash 3.2**: the full unit and acceptance suites run
+  inside an alpine `bash:3.2` Docker image, so no test silently
+  relies on a bash 4+ feature.
+- **CodeQL**: JavaScript/TypeScript and GitHub Actions analysis.
 
-All checks must be green before merge. If a CI failure looks
-unrelated to your change, mention it in the PR body so the maintainer
-can confirm.
+CI runs on every pull request. Pushes to feature branches do not
+trigger CI; open a PR (draft is fine) to see check results. All
+checks must be green before merge. If a CI failure looks unrelated to
+your change, mention it in the PR body so the maintainer can confirm.
 
 ## Parallel agents (optional pattern)
 
@@ -101,7 +105,7 @@ distinct issues in parallel. The pattern, in the most generic form:
 3. Use the agent handle as the branch prefix
    (`<your-agent-handle>/fix/...`) so concurrent branches don't
    collide.
-4. Push under your normal `gh auth` token — no extra setup.
+4. Push under your normal `gh auth` token, no extra setup required.
 
 This pattern requires no extra infrastructure beyond a working
 `gh auth` session.
@@ -121,5 +125,3 @@ These items apply only to the repository maintainer:
   `gh project item-add 1 --owner dfrysinger --url <url>`.
 - Milestone assignment is at the maintainer's discretion; agents
   don't self-assign.
-- The dual-review skill (`/dual-review-local`) is the canonical
-  pre-merge review step for non-trivial diffs.

--- a/STATUS.md
+++ b/STATUS.md
@@ -20,5 +20,5 @@ _(none)_
 
 <!--
 Format:
-- #NNN — short reason it's blocked (waiting on whom / what)
+- #NNN: short reason it's blocked (waiting on whom / what)
 -->

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,15 +1,17 @@
-# Active QRSPI-plus agent work
+# Active qrspi-plus agent work
 
-> Each agent edits this file when it starts and finishes a task.
+> Optional coordination file for parallel agent sessions. Each agent
+> appends a line here when it starts a task and updates it on
+> completion or hand-off. Solo contributors can ignore this file.
 > See `CONTRIBUTING.md` for the full protocol.
 
 ## Active work
 
-- qrspi-echo[bot] → #110 all subagents in agent files (PR #124, draft, started 2026-05-04)
+_(none)_
 
 <!--
 Format:
-- df-agent-alpha → #NNN Short title (PR #MMM, draft|ready, started YYYY-MM-DD)
+- <agent-handle> → #NNN Short title (PR #MMM, draft|ready, started YYYY-MM-DD)
 -->
 
 ## Blocked


### PR DESCRIPTION
## Summary

Rewrite `CONTRIBUTING.md` so it is usable by **any contributor**, not just the maintainer's parallel-Copilot-CLI setup. Drop documentation for tooling no longer in use (per-agent GitHub Apps, `qas-init.sh` JWT mint, 1Password vault).

## What's in

- **`CONTRIBUTING.md`** (full rewrite): issue triage labels and taxonomy, branch-naming convention, commit + PR rules, CI expectations (Lint + BATS under bash:3.2 + CodeQL), an optional **Parallel agents** section describing the pattern (one clone per agent, per-clone `git config --local user.name`, branch prefix matches handle) using `<your-agent-handle>` placeholders. Small **Maintainer notes** section at the bottom for the project-board command and the dual-review skill.
- **`AGENTS.md`** (slim auto-load pointer): drop "bot identities, qas authentication" framing; point at the new CONTRIBUTING.md sections.
- **`STATUS.md`**: drop the `qrspi-echo[bot]` and `df-agent-alpha` examples in favor of generic `<agent-handle>` placeholder; reframe as an optional coordination file.

## What's out

- Repository-internal NATO/folder conventions stay out of the public doc; they live in user-scoped Copilot memory so they travel with the maintainer across repos without leaking into contributor-facing content.
- Historical artifacts under `reviews/`, `docs/superpowers/{plans,specs}/`, `docs/qrspi/`, `tests/fixtures/`, and `PROVENANCE.md` that mention `qrspi-{nato}[bot]` are left as point-in-time records (consistent with the evergreen-scrub policy from #198).

## Verification

- Local diff stat: 3 files changed, 131 insertions(+), 203 deletions(-). Docs-only; no test changes needed.
- Author of this commit demonstrates the per-clone pattern: `agent-delta <1424648+dfrysinger@users.noreply.github.com>`.

## Follow-ups

- Merge ordering note: this branch is based on `main`. PR #198 also edits `AGENTS.md` (milestones rewrite, lines 150-159); PR #199 already replaced `AGENTS.md` with the slim pointer. If #198 lands before #199, that hunk three-way-merges cleanly; if #199 first, #198's `AGENTS.md` hunk needs reconciliation. Recommend: merge #198 → #199 → this PR.
