### PR TITLE
chore: bump plugin + marketplace manifests to 0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "qrspi",
       "description": "QRSPI workflow plugin for agentic software development",
-      "version": "0.1.0",
+      "version": "0.7.0",
       "source": "./",
       "author": {
         "name": "Daniel Frysinger"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qrspi",
   "description": "QRSPI workflow plugin for agentic software development — Goals, Questions, Research, Design, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test, Replan",
-  "version": "0.2.0",
+  "version": "0.7.0",
   "author": {
     "name": "Daniel Frysinger"
   },

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "QRSPI workflow plugin for agentic software development — Goals, Questions, Research, Design, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test, Replan",
-    "version": "0.2.0"
+    "version": "0.7.0"
   },
   "plugins": [
     {
       "name": "qrspi",
       "description": "QRSPI workflow plugin for agentic software development. 16 skills + 41 specialized reviewer/implementer agents implementing a phased pipeline with TDD enforcement, multi-tier review, and per-phase replan gates.",
-      "version": "0.2.0",
+      "version": "0.7.0",
       "source": "./"
     }
   ]

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qrspi",
   "description": "QRSPI workflow plugin for agentic software development — Goals, Questions, Research, Design, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test, Replan",
-  "version": "0.2.0",
+  "version": "0.7.0",
   "author": {
     "name": "Daniel Frysinger"
   },


### PR DESCRIPTION
Align the four manifests with the v0.7 GitHub milestone (12 closed, 3 `[v0.7-followup]` deferred). Manifests were at 0.2.0; this brings them to 0.7.0 in one step.

## Files changed

- `.claude-plugin/plugin.json` (0.2.0 → 0.7.0)
- `.claude-plugin/marketplace.json` (0.1.0 → 0.7.0, was stale from initial scaffold)
- `.github/plugin/plugin.json` (0.2.0 → 0.7.0)
- `.github/plugin/marketplace.json` (0.2.0 → 0.7.0, both `metadata.version` and `plugins[0].version`)

## After merge

- Tag `v0.7.0` on `main`.
- Reinstall via the self-marketplace (`copilot plugin install qrspi@qrspi-plus`) and smoke-test that agent invocation resolves.