### PR TITLE
chore: bump plugin + marketplace manifests to 0.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "qrspi",
       "description": "QRSPI workflow plugin for agentic software development",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "source": "./",
       "author": {
         "name": "Daniel Frysinger"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qrspi",
   "description": "QRSPI workflow plugin for agentic software development — Goals, Questions, Research, Design, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test, Replan",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "Daniel Frysinger"
   },

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "QRSPI workflow plugin for agentic software development — Goals, Questions, Research, Design, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test, Replan",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "plugins": [
     {
       "name": "qrspi",
       "description": "QRSPI workflow plugin for agentic software development. 16 skills + 41 specialized reviewer/implementer agents implementing a phased pipeline with TDD enforcement, multi-tier review, and per-phase replan gates.",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "source": "./"
     }
   ]

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qrspi",
   "description": "QRSPI workflow plugin for agentic software development — Goals, Questions, Research, Design, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test, Replan",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "Daniel Frysinger"
   },

--- a/docs/qrspi/CHANGELOG.md
+++ b/docs/qrspi/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Reverse-chronological list of notable changes to the QRSPI pipeline (skills, agents, scripts, configuration, and pipeline contracts). Newest entry on top. Entries cite the issue number and the spec/plan paths under `docs/superpowers/specs/` and `docs/superpowers/plans/`.
 
+## 2026-05-30 — v0.7.1 hardening: close G7b silent-fallback class + per-host model_routing
+
+Closes the silent-fallback class tracked under G7 / G7a / G7b at all three reachable dispatch paths in `skills/using-qrspi/SKILL.md`: the `trusted_path:` short-circuit, the `validators:` trusted-model re-run, and the missing `model_routing:` backfill path. Each path now halts and reports rather than silently degrading to the agent-bundled default. Anti-pattern vocab pins in `tests/unit/test-using-qrspi-vocab.bats` forbid the literal "silently fall back" / "silently degrade" wording the class was filed against.
+
+Wires per-host `model_routing:` into `config.md` under `claude-code:` and `copilot-cli:` host keys, mapping the `inherit / haiku / sonnet / opus` tier rows to fully versioned model IDs. The dispatcher now resolves agent tier names to versioned model IDs deterministically across both supported hosts. Removes the `model:` frontmatter key from all 41 `agents/*.md` files — tier source canonicalized as `model_role:` plus the per-host `model_routing:` lookup.
+
+Three hotfixes landed alongside the main work (issues closed by this release):
+- **#215** — `agents/qrspi-test-writer.md` tools expanded to `Read, Write, Edit, Bash, Grep, Glob`; behavioral discipline now enforced at the prompt level via a new `## Tool-grant scope (HARD CONSTRAINT)` section.
+- **#222** — `agents/qrspi-finding-verifier.md` "pre-existing" anchor disambiguates work-unit-external vs prior-round code on the same task's branch, using `<diff_file_path>` overlap as the grounding test.
+- **#223** — Apply-fix protocol threshold split: `style|clarity` keep at ≥80, `correctness` keep at ≥70 (lower bar for hardening-relevant correctness gaps that cluster in the 72-78 rubric band).
+
+Test posture: `bats tests/unit/` — 1325/1325 GREEN.
+
+Closes: #42, #175, #185, #186, #187, #202, #204, #205, #215, #222, #223.
+
+Follow-up issues: #248 (agent tool-grant audit), #249 (verifier rubric re-score validation), #250 (verifier threshold tuning).
+
 ## 2026-05-05 — Sonnet→Haiku confidence verifier (#109)
 
 Added a Haiku-class confidence verifier between artifact-level reviewer subagents and the orchestrator's apply/pause dispatch. Reviewers now emit one finding per file under `reviews/{step}/round-NN/<reviewer_tag>.finding-F<NN>.md`; main chat dispatches one `qrspi-finding-verifier` (Haiku) per finding-file in parallel; each verifier writes a sidecar `.score.yml` (it never mutates the original); main chat assembles findings + sidecars + clean markers into `round-NN-verified.md` and reads it exactly once.


### PR DESCRIPTION
Mirrors #203 (`b977466`, 0.7.0 bump). Bumps all four manifests in lockstep + CHANGELOG entry for v0.7.1.

## Manifests bumped (0.7.0 → 0.7.1)

- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json` (plugins[0].version)
- `.github/plugin/plugin.json`
- `.github/plugin/marketplace.json` (metadata.version + plugins[0].version)

## CHANGELOG

Adds v0.7.1 entry to `docs/qrspi/CHANGELOG.md` covering the merged hardening work:

- G7b silent-fallback closure at all 3 dispatch surfaces in `skills/using-qrspi/SKILL.md` (`trusted_path:` short-circuit, `validators:` trusted-model re-run, missing `model_routing:` backfill)
- Per-host `model_routing:` block in `config.md` under `claude-code:` / `copilot-cli:` host keys; agents reference tier roles (`inherit / haiku / sonnet / opus`)
- Removal of `model:` frontmatter from all 41 `agents/*.md` files
- Hotfixes #215 (test-writer tool grants), #222 (verifier 'pre-existing' anchor), #223 (apply-fix threshold split style/clarity ≥80 / correctness ≥70)

## Validation

`bats tests/unit/` — 1325/1325 GREEN.

## Release flow

Merge → tag `v0.7.1` on merged commit → publish GitHub release.

Closes: none (release plumbing only).