### PR TITLE
chore: bump .github/plugin/plugin.json to 0.7.2

### DIFF
--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qrspi",
   "description": "QRSPI workflow plugin for agentic software development — Goals, Questions, Research, Design, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test, Replan",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": {
     "name": "Daniel Frysinger"
   },


### PR DESCRIPTION
Completes the v0.7.2 release.

The `.github/plugin/plugin.json` manifest was missed during the v0.7.2 version bump (PR #299) — only `.claude-plugin/plugin.json` and `build/.claude-plugin/plugin.json` were updated. Copilot CLI's plugin manager reads version metadata from `.github/plugin/plugin.json`, so `/plugin update qrspi@qrspi-plus` reported "v0.7.1, already at latest" after the v0.7.2 release even though the installed payload on disk was already v0.7.2.

This bumps the missed manifest to 0.7.2.

Tracks #277 (PI-HKP-001: two divergent plugin manifest files — `.claude-plugin/` vs `.github/plugin/`); broader consolidation will land in v0.7.3.