### PR TITLE
hotfix(v0.7.2.2): temper Goals scope-reviewer with permitted incidental references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "qrspi",
       "description": "QRSPI workflow plugin for agentic software development",
-      "version": "0.7.2.1",
+      "version": "0.7.2.2",
       "source": "./build",
       "author": {
         "name": "Daniel Frysinger"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qrspi",
   "description": "QRSPI workflow plugin for agentic software development — Goals, Questions, Research, Design, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test, Replan",
-  "version": "0.7.2.1",
+  "version": "0.7.2.2",
   "author": {
     "name": "Daniel Frysinger"
   },

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "QRSPI workflow plugin for agentic software development — Goals, Questions, Research, Design, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test, Replan",
-    "version": "0.7.2.1"
+    "version": "0.7.2.2"
   },
   "plugins": [
     {
       "name": "qrspi",
       "description": "QRSPI workflow plugin for agentic software development. 16 skills + 41 specialized reviewer/implementer agents implementing a phased pipeline with TDD enforcement, multi-tier review, and per-phase replan gates.",
-      "version": "0.7.2.1",
+      "version": "0.7.2.2",
       "source": "./"
     }
   ]

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qrspi",
   "description": "QRSPI workflow plugin for agentic software development — Goals, Questions, Research, Design, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test, Replan",
-  "version": "0.7.2.1",
+  "version": "0.7.2.2",
   "author": {
     "name": "Daniel Frysinger"
   },

--- a/build/.claude-plugin/plugin.json
+++ b/build/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qrspi",
   "description": "QRSPI workflow plugin for agentic software development — Goals, Questions, Research, Design, Phasing, Structure, Plan, Parallelize, Implement, Integrate, Test, Replan",
-  "version": "0.7.2.1",
+  "version": "0.7.2.2",
   "author": {
     "name": "Daniel Frysinger"
   },

--- a/build/skills/goals/SKILL.md
+++ b/build/skills/goals/SKILL.md
@@ -46,6 +46,17 @@ This section is the **single source of truth** for goals.md scope boundaries. It
 - **Phasing decisions, vertical slice authoring, roadmap** → Phasing.
 - **Implementation logic, function signatures, assertion text** → Structure / Plan / Implement.
 
+### Permitted Incidental References
+
+The DEFERS list is about *ownership* of decisions, not *mention* of the deferred surface. The following incidental references are PERMITTED and MUST NOT be flagged as boundary violations by the scope-reviewer:
+
+- **User-locked decisions made during Goals dialogue.** When the user explicitly locks a direction during the Goals interactive dialogue, the artifact MAY record that lock under "What we know so far" using a provenance marker such as `Decision locked during this Goals dialogue:` or `User-locked during Goals dialogue:`. Provenance trumps the candidate-framing rule — the user is the authority, and recording the lock truthfully is more important than re-framing it as a candidate. The lock applies only to the goal's framing, not to Design's downstream decisions about how to implement it.
+- **Acceptance candidates framed as candidates.** Sentences that surface possible acceptance approaches using candidate verbs (`could include`, `Design should weigh`, `candidate acceptance approach:`) are PERMITTED. Sentences that bind acceptance with imperative verbs (`Acceptance must include`, `Acceptance must measure`) are NOT — those still violate the rule.
+- **Cross-goal sequencing intent in Cross-Cutting Notes.** Goals OWNS goal relationships; ordering hints between goals (e.g. "G8 lands last because trimming files G1-G7 edit creates merge churn") are part of expressing those relationships and are PERMITTED in `## Cross-Cutting Notes`. The actual phase boundaries and roadmap are still Phasing's call — Goals records the *coupling rationale*, not the phase decision.
+- **One-sentence mechanism sketches in candidate-fix bullets.** A single sentence describing a candidate fix's mechanism (e.g. "validate actual merge-parent SHAs against named task-tip SHA set; halt on mismatch") is PERMITTED. Multi-line shell pseudocode with specific variable names, command flags, or assertion text is NOT — that level of specificity belongs to Structure / Plan / Implement.
+
+The scope-reviewer evaluates the deferred surface against these carve-outs FIRST before flagging a boundary finding. A scope finding is only valid when the artifact crosses the boundary in a way the carve-outs do not permit.
+
 ## Goal Type Field
 
 Every goal entry MUST carry a `type` field with value `known-fix` or `exploratory`. The field is grounded in **Knight risk-vs-uncertainty**:

--- a/build/skills/goals/owns-defers.md
+++ b/build/skills/goals/owns-defers.md
@@ -20,3 +20,14 @@ This section is the **single source of truth** for goals.md scope boundaries. It
 - **Task specs, LOC estimates, dependencies** → Plan.
 - **Phasing decisions, vertical slice authoring, roadmap** → Phasing.
 - **Implementation logic, function signatures, assertion text** → Structure / Plan / Implement.
+
+### Permitted Incidental References
+
+The DEFERS list is about *ownership* of decisions, not *mention* of the deferred surface. The following incidental references are PERMITTED and MUST NOT be flagged as boundary violations by the scope-reviewer:
+
+- **User-locked decisions made during Goals dialogue.** When the user explicitly locks a direction during the Goals interactive dialogue, the artifact MAY record that lock under "What we know so far" using a provenance marker such as `Decision locked during this Goals dialogue:` or `User-locked during Goals dialogue:`. Provenance trumps the candidate-framing rule — the user is the authority, and recording the lock truthfully is more important than re-framing it as a candidate. The lock applies only to the goal's framing, not to Design's downstream decisions about how to implement it.
+- **Acceptance candidates framed as candidates.** Sentences that surface possible acceptance approaches using candidate verbs (`could include`, `Design should weigh`, `candidate acceptance approach:`) are PERMITTED. Sentences that bind acceptance with imperative verbs (`Acceptance must include`, `Acceptance must measure`) are NOT — those still violate the rule.
+- **Cross-goal sequencing intent in Cross-Cutting Notes.** Goals OWNS goal relationships; ordering hints between goals (e.g. "G8 lands last because trimming files G1-G7 edit creates merge churn") are part of expressing those relationships and are PERMITTED in `## Cross-Cutting Notes`. The actual phase boundaries and roadmap are still Phasing's call — Goals records the *coupling rationale*, not the phase decision.
+- **One-sentence mechanism sketches in candidate-fix bullets.** A single sentence describing a candidate fix's mechanism (e.g. "validate actual merge-parent SHAs against named task-tip SHA set; halt on mismatch") is PERMITTED. Multi-line shell pseudocode with specific variable names, command flags, or assertion text is NOT — that level of specificity belongs to Structure / Plan / Implement.
+
+The scope-reviewer evaluates the deferred surface against these carve-outs FIRST before flagging a boundary finding. A scope finding is only valid when the artifact crosses the boundary in a way the carve-outs do not permit.

--- a/skills/goals/owns-defers.md
+++ b/skills/goals/owns-defers.md
@@ -20,3 +20,14 @@ This section is the **single source of truth** for goals.md scope boundaries. It
 - **Task specs, LOC estimates, dependencies** → Plan.
 - **Phasing decisions, vertical slice authoring, roadmap** → Phasing.
 - **Implementation logic, function signatures, assertion text** → Structure / Plan / Implement.
+
+### Permitted Incidental References
+
+The DEFERS list is about *ownership* of decisions, not *mention* of the deferred surface. The following incidental references are PERMITTED and MUST NOT be flagged as boundary violations by the scope-reviewer:
+
+- **User-locked decisions made during Goals dialogue.** When the user explicitly locks a direction during the Goals interactive dialogue, the artifact MAY record that lock under "What we know so far" using a provenance marker such as `Decision locked during this Goals dialogue:` or `User-locked during Goals dialogue:`. Provenance trumps the candidate-framing rule — the user is the authority, and recording the lock truthfully is more important than re-framing it as a candidate. The lock applies only to the goal's framing, not to Design's downstream decisions about how to implement it.
+- **Acceptance candidates framed as candidates.** Sentences that surface possible acceptance approaches using candidate verbs (`could include`, `Design should weigh`, `candidate acceptance approach:`) are PERMITTED. Sentences that bind acceptance with imperative verbs (`Acceptance must include`, `Acceptance must measure`) are NOT — those still violate the rule.
+- **Cross-goal sequencing intent in Cross-Cutting Notes.** Goals OWNS goal relationships; ordering hints between goals (e.g. "G8 lands last because trimming files G1-G7 edit creates merge churn") are part of expressing those relationships and are PERMITTED in `## Cross-Cutting Notes`. The actual phase boundaries and roadmap are still Phasing's call — Goals records the *coupling rationale*, not the phase decision.
+- **One-sentence mechanism sketches in candidate-fix bullets.** A single sentence describing a candidate fix's mechanism (e.g. "validate actual merge-parent SHAs against named task-tip SHA set; halt on mismatch") is PERMITTED. Multi-line shell pseudocode with specific variable names, command flags, or assertion text is NOT — that level of specificity belongs to Structure / Plan / Implement.
+
+The scope-reviewer evaluates the deferred surface against these carve-outs FIRST before flagging a boundary finding. A scope finding is only valid when the artifact crosses the boundary in a way the carve-outs do not permit.


### PR DESCRIPTION
## Summary

Out-of-band hotfix during v0.7.3 Goals run. Round-1 reviewers fired 5 boundary findings — technically correct per the strict DEFERS list, but over-aggressive against:

- User-locked decisions made during Goals dialogue (treated as commitment leakage)
- Paraphrased issue-body acceptance language framed as candidates (single 'must' word inside an otherwise-candidate-framed bullet)
- Cross-goal sequencing intent in Cross-Cutting Notes (necessary coupling rationale)
- One-sentence mechanism descriptions in candidate-fix bullets

## Change

Adds 'Permitted Incidental References' carve-out to `skills/goals/owns-defers.md`:

1. User-locked decisions with provenance marker trump candidate-framing.
2. Acceptance candidates framed with candidate verbs are permitted; imperative `Acceptance must` still violates.
3. Cross-goal sequencing intent in `## Cross-Cutting Notes` is permitted.
4. One-sentence mechanism sketches in candidate-fix bullets are permitted; multi-line pseudocode still deferred.

Rule: scope-reviewer evaluates carve-outs FIRST before flagging.

## Files

- `skills/goals/owns-defers.md` — new `### Permitted Incidental References` section.
- `build/skills/goals/` — regenerated mirror.
- 5 manifests bumped 0.7.2.1 → 0.7.2.2.

## Plan

Merge → tag → release → `/plugin update` → resume v0.7.3 Goals R2 with calibrated reviewers.