### PR TITLE
hotfix(v0.7.2.4): harden CLI arg parsing on second-reviewer / verifier-fan-in / round-prepare

### DIFF
--- a/scripts/round-prepare.sh
+++ b/scripts/round-prepare.sh
@@ -43,6 +43,23 @@ if [ "$#" -lt 2 ]; then
   exit 1
 fi
 
+# Reject any positional that starts with '-' — these are always a misuse
+# (typo'd flag silently consumed as <round-NN> or <output-dir>). Closes the
+# class-of-bug v0.7.2.4 hotfix fixes elsewhere; see
+# tests/unit/test-round-prepare.bats § "argument hardening".
+case "$1" in
+  -*)
+    echo "round-prepare: positional <round-NN> must not begin with '-' (got: $1)" >&2
+    exit 1
+    ;;
+esac
+case "$2" in
+  -*)
+    echo "round-prepare: positional <output-dir> must not begin with '-' (got: $2)" >&2
+    exit 1
+    ;;
+esac
+
 ROUND="$1"; shift
 OUTPUT_DIR="$1"; shift
 

--- a/scripts/second-reviewer-available.sh
+++ b/scripts/second-reviewer-available.sh
@@ -3,21 +3,28 @@
 #
 # Detects the active host (via _host-detect.sh), looks up the host's default
 # second-reviewer vendor (via _resolve-lib.sh's host x vendor matrix), and exits
-# 0 when that vendor is potentially reachable on this host. An optional positional
-# <vendor> argument overrides the default lookup for operator/diagnostic runs.
+# 0 when that vendor is potentially reachable on this host. An optional
+# `--vendor <name>` flag overrides the default lookup for operator/diagnostic
+# runs.
 #
 # Usage:
-#   second-reviewer-available.sh [<vendor>]
+#   second-reviewer-available.sh [--vendor <name>]
 #
 # Exit 0: the requested/default second-reviewer vendor is potentially available
 #         for the detected host.
 # Exit 1: the detected host names no default second-reviewer vendor, the vendor
 #         is absent from the host x vendor matrix, or the vendor is unreachable.
+# Exit 2: invalid invocation (unknown flag, missing flag value, or positional
+#         argument). Distinct exit code so callers can distinguish a usage
+#         error from a substantive unavailable verdict.
 #
 # Stdout: on success, the resolved vendor id (diagnostic only; not consumed by
 #         SKILL prose).
-# Stderr: on failure, exactly one line beginning `[second-reviewer-unavailable]`
-#         naming the detected host and the requested/default vendor.
+# Stderr: on exit 1, exactly one line beginning `[second-reviewer-unavailable]`
+#         naming the detected host, the requested/default vendor, and the
+#         specific cause (no-default / explicit-none / unrecognized-vendor).
+#         On exit 2, a single-line `second-reviewer-available: <reason>`
+#         diagnostic plus the usage line.
 #
 # Boundary: this probe checks REACHABILITY only. It does NOT read `model_routing:`
 # and does NOT enforce primary/second vendor distinctness — that invariant is
@@ -31,29 +38,89 @@ set -u
 
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
 
+_usage() {
+  echo "Usage: second-reviewer-available.sh [--vendor <name>]" >&2
+}
+
+# Argument parsing. `--vendor <name>` (or `--vendor=<name>`) is the only
+# accepted form. Positional arguments, unknown flags, empty vendor values,
+# and flag-shaped vendor values are rejected with exit 2 so a typo like
+# `--artifact-dir foo` or `--vendor --bogus` cannot be silently consumed as
+# a vendor name (the class-of-bug v0.7.2.4 hotfix closes — see
+# tests/unit/test-second-reviewer-available.bats § "argument hardening").
+_vendor=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --vendor)
+      if [ "$#" -lt 2 ]; then
+        echo "second-reviewer-available: --vendor requires a value" >&2
+        _usage
+        exit 2
+      fi
+      _vendor="$2"
+      shift 2
+      ;;
+    --vendor=*)
+      _vendor="${1#--vendor=}"
+      shift
+      ;;
+    --*)
+      echo "second-reviewer-available: unknown flag: $1" >&2
+      _usage
+      exit 2
+      ;;
+    *)
+      echo "second-reviewer-available: positional arguments not accepted (got: $1)" >&2
+      _usage
+      exit 2
+      ;;
+  esac
+  # Validate the vendor value at the parse site so empty / flag-shaped values
+  # are rejected as invocation errors (exit 2), not silently treated as "use
+  # default" (which masks a typo) and not later misreported as substantive
+  # unavailability (exit 1, the misleading-error class the hotfix exists to
+  # fix). Only enforce on branches that just assigned to _vendor.
+  case "$_vendor" in
+    "")
+      echo "second-reviewer-available: --vendor requires a non-empty value" >&2
+      _usage
+      exit 2
+      ;;
+    -*)
+      echo "second-reviewer-available: --vendor value must not begin with '-' (got: $_vendor)" >&2
+      _usage
+      exit 2
+      ;;
+  esac
+done
+
 # Source the shared host-detection primitive and routing-resolution library
 # under their source-only guards so no wrapper main logic runs.
 QRSPI_SOURCE_ONLY=1 . "$_SCRIPT_DIR/_host-detect.sh"
 QRSPI_SOURCE_ONLY=1 . "$_SCRIPT_DIR/_resolve-lib.sh"
 
 _host="$(detect_host)"
-
 _default_vendor="$(lookup_default_second_reviewer "$_host")"
 
-# optional <vendor> override; else the host default
-if [ "$#" -ge 1 ] && [ -n "$1" ]; then
-  _vendor="$1"
-else
+if [ -z "$_vendor" ]; then
   _vendor="$_default_vendor"
 fi
 
-# Unavailable when: the default vendor lookup yielded an empty string (e.g. a
-# missing or failed lookup — treated as no configured second reviewer), the host
-# names no default second-reviewer vendor (unknown/unsupported host — reachability
-# is host-dependent, so an override cannot make an unsupported host available),
-# the requested vendor is `none`, or the vendor is not a recognised matrix vendor.
-if [ -z "$_default_vendor" ] || [ "$_default_vendor" = "none" ] || [ "$_vendor" = "none" ] || ! second_reviewer_vendor_known "$_vendor"; then
-  printf '[second-reviewer-unavailable] host=%s vendor=%s — no reachable second reviewer for this host\n' \
+# Substantive unavailability — exit 1 with a cause-specific diagnostic so the
+# operator can distinguish "this host has no default" from "the matrix doesn't
+# know this vendor name" from "explicit none".
+if [ -z "$_default_vendor" ] || [ "$_default_vendor" = "none" ]; then
+  printf '[second-reviewer-unavailable] host=%s vendor=%s — host names no default second-reviewer vendor\n' \
+    "$_host" "$_vendor" >&2
+  exit 1
+fi
+if [ "$_vendor" = "none" ]; then
+  printf '[second-reviewer-unavailable] host=%s vendor=none — explicit none\n' \
+    "$_host" >&2
+  exit 1
+fi
+if ! second_reviewer_vendor_known "$_vendor"; then
+  printf '[second-reviewer-unavailable] host=%s vendor=%s — unrecognized vendor (expected one of: openai-codex, anthropic-claude); pass --vendor <name> or omit for host default\n' \
     "$_host" "$_vendor" >&2
   exit 1
 fi

--- a/scripts/verifier-fan-in.sh
+++ b/scripts/verifier-fan-in.sh
@@ -76,6 +76,18 @@ if [[ $# -lt 1 ]]; then
   exit 2
 fi
 
+# Reject any positional that starts with '-' — these are always a misuse
+# (typo'd flag silently consumed as <round-dir>). Closes the class-of-bug
+# v0.7.2.4 hotfix fixes elsewhere; see tests/unit/test-verifier-fan-in-script.bats
+# § "argument hardening".
+case "$1" in
+  -*)
+    echo "verifier-fan-in: positional <round-dir> must not begin with '-' (got: $1)" >&2
+    usage
+    exit 2
+    ;;
+esac
+
 ROUND_DIR="$1"
 
 if [[ ! -d "$ROUND_DIR" ]]; then

--- a/tests/unit/test-round-prepare.bats
+++ b/tests/unit/test-round-prepare.bats
@@ -609,3 +609,29 @@ for s in ('skills/using-qrspi/SKILL.md','skills/reviewer-protocol/SKILL.md','ski
     assert s in sources, 'missing manifest source: '+s
 "
 }
+
+# ============================================================================
+# Argument hardening (v0.7.2.4 hotfix) — reject silent flag-typo consumption
+# ============================================================================
+
+# Test expectation: a `--`-prefixed positional in slot 1 (would be <round-NN>)
+# is rejected — not silently consumed and passed along as the round identifier
+# (which would later surface as a baffling git or sidecar error). Closes the
+# class-of-bug v0.7.2.4 fixes across the script suite.
+@test "argument hardening: --flag-shaped positional <round-NN> is rejected (exit 1)" {
+  cd "$TEST_ROOT/repo"
+  run "$PREP" --task-branch foo bar
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"must not begin with '-'"* ]]
+  [[ "$output" == *"<round-NN>"* ]]
+}
+
+# Test expectation: a `--`-prefixed positional in slot 2 (would be <output-dir>)
+# is rejected — not silently consumed and used as the output directory path.
+@test "argument hardening: --flag-shaped positional <output-dir> is rejected (exit 1)" {
+  cd "$TEST_ROOT/repo"
+  run "$PREP" 1 --output-dir foo
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"must not begin with '-'"* ]]
+  [[ "$output" == *"<output-dir>"* ]]
+}

--- a/tests/unit/test-second-reviewer-available.bats
+++ b/tests/unit/test-second-reviewer-available.bats
@@ -327,7 +327,7 @@ teardown() {
   local _status=0
   bash -c "
     export COPILOT_CLI=1
-    \"$SECOND_REVIEWER\" nonexistent-vendor-xyz
+    \"$SECOND_REVIEWER\" --vendor nonexistent-vendor-xyz
   " >/dev/null 2>"$_stderr_file" || _status=$?
   [ "$_status" -ne 0 ]
   grep -q '^\[second-reviewer-unavailable\]' "$_stderr_file"
@@ -348,7 +348,7 @@ teardown() {
   local _stderr_file="$TMP_DIR/unavail-override-vendor.txt"
   bash -c "
     export COPILOT_CLI=1
-    \"$SECOND_REVIEWER\" nonexistent-vendor-xyz
+    \"$SECOND_REVIEWER\" --vendor nonexistent-vendor-xyz
   " >/dev/null 2>"$_stderr_file" || true
   grep -q 'vendor=nonexistent-vendor-xyz' "$_stderr_file"
 }
@@ -364,7 +364,7 @@ teardown() {
   local _status=0
   bash -c "
     export COPILOT_CLI=1
-    \"$SECOND_REVIEWER\" none
+    \"$SECOND_REVIEWER\" --vendor none
   " >/dev/null 2>"$_stderr_file" || _status=$?
 
   # Must exit non-zero — 'none' is explicitly unavailable
@@ -392,7 +392,7 @@ teardown() {
   # Test expectation: COPILOT_CLI=1 with explicit 'openai-codex' override exits 0.
   run bash -c "
     export COPILOT_CLI=1
-    \"$SECOND_REVIEWER\" openai-codex
+    \"$SECOND_REVIEWER\" --vendor openai-codex
   "
   [ "$status" -eq 0 ]
 }
@@ -404,7 +404,7 @@ teardown() {
   # equal the primary — that distinctness check lives at dispatch time, not here.
   run bash -c "
     export COPILOT_CLI=1
-    \"$SECOND_REVIEWER\" anthropic-claude
+    \"$SECOND_REVIEWER\" --vendor anthropic-claude
   "
   [ "$status" -eq 0 ]
 }
@@ -431,7 +431,7 @@ teardown() {
   # anthropic-claude — the probe should not care and should exit 0.
   run bash -c "
     export COPILOT_CLI=1
-    \"$SECOND_REVIEWER\" anthropic-claude
+    \"$SECOND_REVIEWER\" --vendor anthropic-claude
   "
   [ "$status" -eq 0 ]
 }
@@ -491,7 +491,7 @@ teardown() {
   local _status=0
   bash -c "
     unset COPILOT_CLI CLAUDE_PROJECT_DIR CODEX_CLI
-    \"$SECOND_REVIEWER\" openai-codex
+    \"$SECOND_REVIEWER\" --vendor openai-codex
   " >/dev/null 2>"$_stderr_file" || _status=$?
 
   # Must exit non-zero — an unknown host is never available
@@ -554,7 +554,7 @@ EOF
   local _status=0
   bash -c "
     unset COPILOT_CLI CLAUDE_PROJECT_DIR CODEX_CLI
-    \"$_work_dir/second-reviewer-available.sh\" openai-codex
+    \"$_work_dir/second-reviewer-available.sh\" --vendor openai-codex
   " >/dev/null 2>"$_stderr_file" || _status=$?
 
   # Must exit non-zero — an empty default vendor means no configured second reviewer
@@ -569,4 +569,113 @@ EOF
   # Diagnostic must name the detected host and the requested vendor (naming contract)
   grep -q 'host=' "$_stderr_file"
   grep -q 'vendor=' "$_stderr_file"
+}
+
+# ===========================================================================
+# Argument hardening (v0.7.2.4 hotfix) — reject silent flag-typo consumption
+# ===========================================================================
+
+# Test expectation: a `--`-prefixed positional (e.g. `--artifact-dir foo`) must
+# be rejected with exit 2 and a clear "unknown flag" diagnostic — not silently
+# consumed as a vendor name. This is the regression test for the v0.7.2.4
+# class-of-bug where a typo'd flag flowed into vendor lookup and produced the
+# misleading "no reachable second reviewer" verdict.
+@test "argument hardening: --flag-shaped positional is rejected (unknown flag, exit 2)" {
+  run bash -c "
+    export COPILOT_CLI=1
+    \"$SECOND_REVIEWER\" --artifact-dir foo
+  "
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+  [[ "$output" == *"--artifact-dir"* ]]
+}
+
+# Test expectation: a bare positional vendor argument is rejected (the legacy
+# back-compat form was deliberately dropped — --vendor is the only accepted form).
+@test "argument hardening: bare positional vendor is rejected (positional not accepted, exit 2)" {
+  run bash -c "
+    export COPILOT_CLI=1
+    \"$SECOND_REVIEWER\" openai-codex
+  "
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"positional arguments not accepted"* ]]
+}
+
+# Test expectation: --vendor with no value is rejected with exit 2.
+@test "argument hardening: --vendor with no value is rejected (exit 2)" {
+  run bash -c "
+    export COPILOT_CLI=1
+    \"$SECOND_REVIEWER\" --vendor
+  "
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--vendor requires a value"* ]]
+}
+
+# Test expectation: --vendor=<value> equals form is accepted.
+@test "argument hardening: --vendor=<value> equals-form is accepted (exit 0)" {
+  run bash -c "
+    export COPILOT_CLI=1
+    \"$SECOND_REVIEWER\" --vendor=openai-codex
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "openai-codex" ]
+}
+
+# Test expectation: unknown flag (any --xxx other than --vendor) exits 2.
+@test "argument hardening: unknown --flag is rejected (exit 2)" {
+  run bash -c "
+    export COPILOT_CLI=1
+    \"$SECOND_REVIEWER\" --bogus-flag
+  "
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+# Test expectation: --vendor= (equals form with empty value) is rejected.
+# Codex review r1 finding: empty equals-form was silently falling back to
+# default, masking typos of the form `--vendor=$UNSET_VAR`.
+@test "argument hardening: --vendor= (empty equals-form) is rejected (exit 2)" {
+  run bash -c "
+    export COPILOT_CLI=1
+    \"$SECOND_REVIEWER\" --vendor=
+  "
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--vendor requires a non-empty value"* ]]
+}
+
+# Test expectation: --vendor "" (empty space-form value) is rejected.
+@test "argument hardening: --vendor \"\" (empty space-form) is rejected (exit 2)" {
+  run bash -c "
+    export COPILOT_CLI=1
+    \"$SECOND_REVIEWER\" --vendor ''
+  "
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--vendor requires a non-empty value"* ]]
+}
+
+# Test expectation: --vendor --bogus (flag-shaped vendor value) is rejected
+# with exit 2 — not exit 1 (substantive unavailability), which would
+# reintroduce the misleading-error class the v0.7.2.4 hotfix exists to fix.
+# Codex review r1 finding: parser was accepting --bogus as a vendor value,
+# then reporting "unrecognized vendor" via exit 1 (substantive) instead of
+# rejecting at the invocation boundary via exit 2.
+@test "argument hardening: --vendor --bogus (flag-shaped value) is rejected (exit 2)" {
+  run bash -c "
+    export COPILOT_CLI=1
+    \"$SECOND_REVIEWER\" --vendor --bogus
+  "
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--vendor value must not begin with '-'"* ]]
+  [[ "$output" == *"--bogus"* ]]
+}
+
+# Test expectation: --vendor=--bogus (flag-shaped value via equals form) is
+# rejected with exit 2 — same class as above via the equals-form parse path.
+@test "argument hardening: --vendor=--bogus (flag-shaped equals-form) is rejected (exit 2)" {
+  run bash -c "
+    export COPILOT_CLI=1
+    \"$SECOND_REVIEWER\" --vendor=--bogus
+  "
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--vendor value must not begin with '-'"* ]]
 }

--- a/tests/unit/test-verifier-fan-in-script.bats
+++ b/tests/unit/test-verifier-fan-in-script.bats
@@ -520,3 +520,25 @@ EOF
   [ "$status" -ne 0 ]
   [[ "$output" == *"awk"* || "$stderr" == *"awk"* ]]
 }
+
+# ===========================================================================
+# Argument hardening (v0.7.2.4 hotfix) — reject silent flag-typo consumption
+# ===========================================================================
+
+# Test expectation: a `--`-prefixed positional must be rejected with exit 2 and
+# a clear "must not begin with '-'" diagnostic — not silently consumed as
+# <round-dir> (which would then surface as a confusing "does not exist" or
+# downstream JSON error). Closes the class-of-bug v0.7.2.4 fixes across the
+# script suite.
+@test "argument hardening: --flag-shaped positional <round-dir> is rejected (exit 2)" {
+  run bash "$SCRIPT" --output foo
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"must not begin with '-'"* ]]
+  [[ "$output" == *"--output"* ]]
+}
+
+@test "argument hardening: legit positional <round-dir> still works after guard (non-existent dir → exit 2 with 'does not exist')" {
+  run bash "$SCRIPT" /nonexistent-round-dir-for-guard-test
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"does not exist"* ]]
+}


### PR DESCRIPTION
## Summary

Closes a class-of-bug where positional-arg scripts silently consumed typo'd long-flags as positional values, producing misleading downstream errors.

**Trigger**: During v0.7.3 self-host, `scripts/second-reviewer-available.sh --artifact-dir foo` was misread by the script as `vendor=--artifact-dir`, then reported a confusing `[second-reviewer-unavailable] host=copilot-cli vendor=--artifact-dir` line that masked pilot error as architectural gap. Fix: reject the malformed invocation at the parse boundary with exit 2.

## Changes

- `scripts/second-reviewer-available.sh`: full rewrite to `--vendor`-only. Rejects positional args, unknown flags, empty values (`--vendor=`, `--vendor ""`), and flag-shaped values (`--vendor --bogus`, `--vendor=--bogus`) at the parse boundary with exit 2. Preserves the single-line `[second-reviewer-unavailable] host=X vendor=Y` stderr invariant for the three legitimate exit-1 diagnostic paths.
- `scripts/verifier-fan-in.sh`: `case "$1" in -*) reject` guard before the single `<round-dir>` positional, exit 2.
- `scripts/round-prepare.sh`: same guard for both positionals (`<round-NN>` and `<output-dir>`), exit 1 to match the script's existing arg-count convention.

## Test coverage

- `tests/unit/test-second-reviewer-available.bats`: 8 positional-form invocations rewritten to `--vendor` form; **+9 hardening tests** covering positional rejection, unknown flag rejection, empty values (equals + space form), flag-shaped values (equals + space form), and known-vendor acceptance via both forms.
- `tests/unit/test-verifier-fan-in-script.bats`: **+2 hardening tests**.
- `tests/unit/test-round-prepare.bats`: **+2 hardening tests**.

**Unit suite: 1956 tests pass, 0 fail.**

## Dual-review

`claude-opus-4.7-high` + `gpt-5.5` in parallel, **2 rounds to clean**.

- **Round 1**: 2 medium correctness findings — empty-value silent fallback (both reviewers) + flag-shaped-value exit-1 misclassification (Codex only).
- **Round 2**: both reviewers returned zero in-scope findings with verbatim evidence that the round-1 issues were resolved.

## Deferred follow-up

#316 tracks full long-flag standardization for `verifier-fan-in.sh` and `round-prepare.sh` (current hotfix only adds the leading flag-rejection guard; the positionals themselves remain positional pending the larger refactor).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>