### PR TITLE
hotfix(v0.7.2.6): refresh codex fallback model id (#318)

### DIFF
--- a/scripts/dispatch-agent.sh
+++ b/scripts/dispatch-agent.sh
@@ -689,7 +689,7 @@ if [[ "$_is_batch_mode" == "true" ]]; then
   # emitted so the operator knows resolution degraded to a default.
   _fallback_model_for_vendor() {
     case "$1" in
-      codex) printf 'gpt-5-codex\n' ;;
+      codex) printf 'gpt-5.3-codex\n' ;;
       *)     printf 'claude-sonnet-4.6\n' ;;
     esac
   }


### PR DESCRIPTION
Single-token swap on `_fallback_model_for_vendor` codex arm: `gpt-5-codex` → `gpt-5.3-codex`. The stale identifier was silently failing every codex reviewer launch (model not in Copilot CLI catalog). Closes #318.